### PR TITLE
Support ES6 in our jasmine tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,15 @@
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "browsers": ["last 2 versions", "Explorer >= 11"],
+        "node": "current"
+      }
+    }]
+  ],
+  "plugins": [
+    ["babel-root-import", {
+      "rootPathSuffix": "src"
+    }]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bundle": "webpack --progress --colors",
     "dev": "webpack --progress --colors --watch",
-    "test": "eslint . && istanbul cover --include-all-sources jasmine-node tests"
+    "test": "eslint . && istanbul cover --include-all-sources babel-node node_modules/.bin/jasmine"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-cli": "^6.18.0",
     "babel-loader": "^6.2.10",
     "babel-preset-env": "^1.0.2",
+    "babel-root-import": "^4.1.5",
     "eslint": "^3.12.1",
     "eslint-plugin-import": "^2.2.0",
     "html-loader": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-import": "^2.2.0",
     "html-loader": "^0.4.4",
     "istanbul": "^0.4.5",
+    "jasmine": "^2.5.2",
     "jasmine-node": "^1.14.5",
     "webpack": "^2.2.0-rc.0"
   },

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "tests/**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,7 +1,7 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "tests/**/*[sS]pec.js"
+    "tests/**/*Spec.js"
   ],
   "helpers": [
     "helpers/**/*.js"

--- a/spec/tests/.eslintrc.json
+++ b/spec/tests/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "jasmine": true
+  },
+  "globals": {
+    "inject": false,
+    "module": false
+  },
+  "plugins": ["jasmine"],
+  "rules": {
+    "jasmine/no-focused-tests": 2,
+    "jasmine/no-suite-callback-args": 2,
+    "max-len": [2, 100, 4, {"ignorePattern": "^import\\s|^\\s*x?it\\("}],
+    "no-console": 0
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,16 +15,7 @@ module.exports = {
       exclude: [
         path.resolve(__dirname, 'node_modules')
       ],
-      loader: 'babel-loader',
-      options: {
-        presets: [
-          ['env', {
-            'targets': {
-              'browsers': ['last 2 versions', 'Explorer >= 11']
-            }
-          }]
-        ]
-      }
+      loader: 'babel-loader'
     }, {
       test: /\.html$/,
       include: [


### PR DESCRIPTION
Need to run the jasmine binary through `babel-node` and move things to the `spec/` folder to get everything set up correctly.