### PR TITLE
Perform repeat logic in compile phase instead.

### DIFF
--- a/examples/category-results-materialize.html
+++ b/examples/category-results-materialize.html
@@ -26,7 +26,8 @@
               <h5>{{suggestion.make_country}}</h5>
             </dt>
             <dd>
-              <ngc-omnibox-suggestion-item class="collection-item">
+              <ngc-omnibox-suggestion-item class="collection-item"
+                  ng-class="{'active': omnibox.isHighlighted(suggestion)}">
                 {{suggestion.make_display}}
               </ngc-omnibox-suggestion-item>
             </dd>

--- a/examples/category-results-materialize.html
+++ b/examples/category-results-materialize.html
@@ -21,11 +21,14 @@
           source="demo.sourceFn(query)">
 
         <ngc-omnibox-suggestions class="collection with-header">
-          <dl ng-repeat="(country, makes) in omnibox.suggestions">
-            <dt class="collection-header"><h5>{{country}}</h5></dt>
-            <dd class="collection-item" ngc-omnibox-suggestion-item ng-repeat="suggestion in makes"
-                ng-class="{'active': omnibox.highlightedIndex == suggestionItem.getIndex()}">
-              {{suggestion.make_display}}
+          <dl ngc-omnibox-suggestion-category>
+            <dt class="collection-header">
+              <h5>{{suggestion.make_country}}</h5>
+            </dt>
+            <dd>
+              <ngc-omnibox-suggestion-item class="collection-item">
+                {{suggestion.make_display}}
+              </ngc-omnibox-suggestion-item>
             </dd>
           </dl>
         </ngc-omnibox-suggestions>
@@ -34,7 +37,6 @@
 
     <script src="../dist/ngc-omnibox.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/2.5.0/fuse.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.2/lodash.min.js"></script>
     <script type="text/javascript">
       angular
         .module('demoApp', ['ngc.omnibox'])
@@ -59,8 +61,25 @@
 
           this.sourceFn = function (query) {
             if (fuse && query) {
-              var byCountry = _.groupBy(fuse.search(query), 'make_country');
-              return $q.resolve(byCountry);
+              const grouped = {};
+              const results = fuse.search(query);
+
+              // Populate groups with results
+              results.forEach((result) => {
+                const groupName = result.make_country;
+                if (!grouped[groupName]) {
+                  grouped[groupName] = {
+                    make_country: result.make_country,
+                    children: []
+                  };
+                }
+
+                grouped[groupName].children.push(result);
+              });
+
+              const data = Object.keys(grouped).map((groupName) => grouped[groupName]);
+
+              return $q.resolve(data);
             } else {
               return $q.resolve(); // Hides the suggestions
             }

--- a/examples/category-results.html
+++ b/examples/category-results.html
@@ -12,11 +12,13 @@
           autofocus="true"
           source="demo.sourceFn(query)">
 
-        <ngc-omnibox-suggestions>
-          <dl ng-repeat="(country, makes) in omnibox.suggestions">
-            <dt>{{country}}</dt>
-            <dd ngc-omnibox-suggestion-item ng-repeat="suggestion in makes">
-              {{suggestion.make_display}}
+        <ngc-omnibox-suggestions class="collection with-header">
+          <dl ngc-omnibox-suggestion-category>
+            <dt>
+              <h5>{{suggestion.make_country}}</h5>
+            </dt>
+            <dd>
+              <ngc-omnibox-suggestion-item>{{suggestion.make_display}}</ngc-omnibox-suggestion-item>
             </dd>
           </dl>
         </ngc-omnibox-suggestions>
@@ -50,8 +52,25 @@
 
           this.sourceFn = function (query) {
             if (fuse && query) {
-              var byCountry = _.groupBy(fuse.search(query), 'make_country');
-              return $q.resolve(byCountry);
+              const grouped = {};
+              const results = fuse.search(query);
+
+              // Populate groups with results
+              results.forEach((result) => {
+                const groupName = result.make_country;
+                if (!grouped[groupName]) {
+                  grouped[groupName] = {
+                    make_country: result.make_country,
+                    children: []
+                  };
+                }
+
+                grouped[groupName].children.push(result);
+              });
+
+              const data = Object.keys(grouped).map((groupName) => grouped[groupName]);
+
+              return $q.resolve(data);
             } else {
               return $q.resolve(); // Hides the suggestions
             }

--- a/examples/simple-suggest-materialize.html
+++ b/examples/simple-suggest-materialize.html
@@ -28,8 +28,7 @@
 
         <ngc-omnibox-suggestions class="collection">
           <ngc-omnibox-suggestion-item class="collection-item"
-              ng-repeat="suggestion in omnibox.suggestions"
-              ng-class="{'active': omnibox.highlightedIndex == getIndex()}">
+              ng-class="{'active': omnibox.isActive(suggestion)}">
             <img ng-attr-src="{{suggestion.url}}" >
           </ngc-omnibox-suggestion-item>
         </ngc-omnibox-suggestions>

--- a/examples/simple-suggest-materialize.html
+++ b/examples/simple-suggest-materialize.html
@@ -28,8 +28,8 @@
 
         <ngc-omnibox-suggestions class="collection">
           <ngc-omnibox-suggestion-item class="collection-item"
-              ng-class="{'active': omnibox.isActive(suggestion)}">
-            <img ng-attr-src="{{suggestion.url}}" >
+              ng-class="{'active': omnibox.isHighlighted(suggestion)}">
+             <img ng-attr-src="{{suggestion.url}}" >
           </ngc-omnibox-suggestion-item>
         </ngc-omnibox-suggestions>
       </ngc-omnibox>

--- a/examples/simple-suggest.html
+++ b/examples/simple-suggest.html
@@ -15,7 +15,7 @@
           source="demo.sourceFn(query)">
 
         <ngc-omnibox-suggestions>
-          <ngc-omnibox-suggestion-item ng-repeat="suggestion in omnibox.suggestions">
+          <ngc-omnibox-suggestion-item>
             <img ng-attr-src="{{suggestion.url}}" >
           </ngc-omnibox-suggestion-item>
         </ngc-omnibox-suggestions>

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -52,6 +52,8 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
   describe('when navigating via the keyboard', () => {
     it('should highlight the next suggestion', () => {
+      ['test', 'me'].forEach((item) => omniboxController.registerItem(item));
+
       expect(omniboxController.highlightedIndex).toBe(-1);
 
       omniboxController.highlightNext();
@@ -62,6 +64,8 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should highlight the previous suggestion', () => {
+      ['test', 'me', 'too'].forEach((item) => omniboxController.registerItem(item));
+
       omniboxController.highlightedIndex = 1;
 
       omniboxController.highlightPrevious();
@@ -69,6 +73,7 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should wrap around the selection', () => {
+      ['test', 'me', 'again', 'please'].forEach((item) => omniboxController.registerItem(item));
       omniboxController.highlightedIndex = 0;
 
       omniboxController.highlightPrevious();

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -22,7 +22,7 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
       expect(omniboxController.hasSuggestions()).toBe(false);
     });
 
-    it('should return false for suggestions that aren\'t Arrays or Objects', () => {
+    it('should return false for suggestions that aren\'t an Array', () => {
       omniboxController.suggestions = 'false';
       expect(omniboxController.hasSuggestions()).toBe(false);
 
@@ -31,21 +31,18 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
       omniboxController.suggestions = 100;
       expect(omniboxController.hasSuggestions()).toBe(false);
-    });
-
-    it('should return false for empty Arrays and Objects', () => {
-      omniboxController.suggestions = [];
-      expect(omniboxController.hasSuggestions()).toBe(false);
-
-      omniboxController.suggestions = {};
-      expect(omniboxController.hasSuggestions()).toBe(false);
-    });
-
-    it('should return true for non-empty Arrays and Objects', () => {
-      omniboxController.suggestions = ['test', 'me'];
-      expect(omniboxController.hasSuggestions()).toBe(true);
 
       omniboxController.suggestions = {test: 'me'};
+      expect(omniboxController.hasSuggestions()).toBe(false);
+    });
+
+    it('should return false for empty Arrays', () => {
+      omniboxController.suggestions = [];
+      expect(omniboxController.hasSuggestions()).toBe(false);
+    });
+
+    it('should return true for non-empty Arrays', () => {
+      omniboxController.suggestions = ['test', 'me'];
       expect(omniboxController.hasSuggestions()).toBe(true);
     });
   });

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -76,11 +76,7 @@ export default class NgcOmniboxController {
   hasSuggestions() {
     const suggestions = this.suggestions;
 
-    if (!suggestions || (!Array.isArray(suggestions) && typeof suggestions !== 'object')) {
-      return false;
-    } else if (Array.isArray(suggestions) && !suggestions.length) {
-      return false;
-    } else if (typeof suggestions === 'object' && !Object.keys(suggestions).length) {
+    if (!suggestions || !Array.isArray(suggestions) || !suggestions.length) {
       return false;
     }
 

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -37,7 +37,8 @@ export default class NgcOmniboxController {
    * @param {Object} item
    */
   deregisterItem(item) {
-    this._suggestionItems.indexOf(item);
+    const index = this._suggestionItems.indexOf(item);
+    this._suggestionItems.splice(index, 1);
   }
 
   onInputChange() {

--- a/src/angularComponent/ngcOmniboxSuggestionItemController.js
+++ b/src/angularComponent/ngcOmniboxSuggestionItemController.js
@@ -1,3 +1,16 @@
 export default class NgcOmniboxSuggestionItemController {
+  static get $inject() {
+    return ['$scope'];
+  }
+  constructor($scope) {
+    this.$scope = $scope;
+  }
+  $onInit() {
+    this.omnibox = this.$scope.omnibox;
+    this.omnibox.registerItem(this.suggestion);
 
+  }
+  $onDestroy() {
+    this.omnibox.deregisterItem(this.index);
+  }
 }

--- a/src/angularComponent/ngcOmniboxSuggestionItemController.js
+++ b/src/angularComponent/ngcOmniboxSuggestionItemController.js
@@ -1,12 +1,5 @@
 export default class NgcOmniboxSuggestionItemController {
-  static get $inject() {
-    return ['$scope'];
-  }
-  constructor($scope) {
-    this.$scope = $scope;
-  }
   $onInit() {
-    this.omnibox = this.$scope.omnibox;
     this.omnibox.registerItem(this.suggestion);
 
   }

--- a/src/angularComponent/ngcOmniboxSuggestionItemDirective.js
+++ b/src/angularComponent/ngcOmniboxSuggestionItemDirective.js
@@ -3,7 +3,10 @@ import NgcOmniboxSuggestionItemController from './ngcOmniboxSuggestionItemContro
 export default function ngcOmniboxSuggestionItemDirective() {
   return {
     restrict: 'AE',
-    require: ['^^ngcOmnibox', '^^ngcOmniboxSuggestions'],
+    require: {
+      omnibox: '^^ngcOmnibox',
+      suggestions: '^^ngcOmniboxSuggestions'
+    },
     scope: true,
     bindToController: {
       suggestion: '<'

--- a/src/angularComponent/ngcOmniboxSuggestionItemDirective.js
+++ b/src/angularComponent/ngcOmniboxSuggestionItemDirective.js
@@ -1,23 +1,21 @@
-import {SUGGESTION_ITEM_NAME} from './ngcOmniboxController.js';
 import NgcOmniboxSuggestionItemController from './ngcOmniboxSuggestionItemController.js';
 
-export default function ngcOmniboxSuggestionsDirective() {
+export default function ngcOmniboxSuggestionItemDirective() {
   return {
     restrict: 'AE',
     require: ['^^ngcOmnibox', '^^ngcOmniboxSuggestions'],
     scope: true,
+    bindToController: {
+      suggestion: '<'
+    },
     controller: NgcOmniboxSuggestionItemController,
     controllerAs: 'suggestionItem',
     compile(tElement) {
-      // Allows us to use document.getElementsByName which is fast AND returns a live-updating
-      // HTMLCollection
-      tElement.attr('name', SUGGESTION_ITEM_NAME);
       tElement.attr('role', 'option');
 
       return {
         pre(scope, iElement, iAttrs, [omnibox]) {
           scope.omnibox = omnibox;
-          scope.suggestionItem.getIndex = () => omnibox.getSuggestionItemIndex(iElement[0]);
         }
       };
     }

--- a/src/angularComponent/ngcOmniboxSuggestionsController.js
+++ b/src/angularComponent/ngcOmniboxSuggestionsController.js
@@ -1,13 +1,2 @@
 export default class NgcOmniboxSuggestionsController {
-  static get $inject() {
-    return ['$scope'];
-  }
-
-  constructor($scope) {
-    this.$scope = $scope;
-  }
-
-  $postLink() {
-    this.omnibox = this.$scope.omnibox;
-  }
 }

--- a/src/angularComponent/ngcOmniboxSuggestionsDirective.js
+++ b/src/angularComponent/ngcOmniboxSuggestionsDirective.js
@@ -69,11 +69,13 @@ export default function ngcOmniboxSuggestionsDirective($document, $templateCache
       categoryContainer.appendChild(categoryEl);
       categoryContainer.appendChild(itemEl);
       itemEl.setAttribute('ng-if', '!suggestion.children');
+      itemEl.setAttribute('suggestion', 'suggestion');
 
       $templateCache.put(templateCacheName, categoryContainer.innerHTML);
       return categoryContainer.outerHTML;
     } else if (itemEl) {
       itemEl.setAttribute('ng-repeat', 'suggestion in omnibox.suggestions');
+      itemEl.setAttribute('suggestion', 'suggestion');
       return itemEl.outerHTML;
     } else {
       throw new Error('ngcOmniboxSuggestions requires an ngcOmniboxSuggestionItem');

--- a/src/angularComponent/ngcOmniboxSuggestionsDirective.js
+++ b/src/angularComponent/ngcOmniboxSuggestionsDirective.js
@@ -1,6 +1,8 @@
+import angular from 'angular';
 import NgcOmniboxSuggestionsController from './ngcOmniboxSuggestionsController.js';
 
-export default function ngcOmniboxSuggestionsDirective() {
+ngcOmniboxSuggestionsDirective.$inject = ['$templateCache'];
+export default function ngcOmniboxSuggestionsDirective($templateCache) {
   return {
     restrict: 'E',
     require: '^^ngcOmnibox',
@@ -8,7 +10,44 @@ export default function ngcOmniboxSuggestionsDirective() {
     controller: NgcOmniboxSuggestionsController,
     controllerAs: 'suggestions',
     compile(tElement) {
-      tElement.attr('role', 'listbox');
+      const el = tElement[0];
+      el.setAttribute('role', 'listbox');
+
+      const categoryEl = el.querySelector(
+        'ngc-omnibox-suggestion-category, [ngc-omnibox-suggestion-category]'
+      );
+      const itemEl = el.querySelector(
+        'ngc-omnibox-suggestion-item, [ngc-omnibox-suggestion-item]'
+      );
+
+      if (categoryEl) {
+        const categoryContainer = angular.element('<div></div>')[0];
+        categoryContainer.setAttribute('ng-repeat',
+            'suggestion in suggestion.children || omnibox.suggestions');
+        categoryEl.setAttribute('ng-if', 'suggestion.children');
+
+        const itemChildrenEl = angular.element('<div></div>')[0];
+        itemChildrenEl.setAttribute('ngc-omnibox-suggestion-item', '');
+        itemChildrenEl.setAttribute('ng-repeat', 'suggestion in suggestion.children');
+        itemChildrenEl.setAttribute('ng-include', '\'category-tmpl\'');
+        if (itemEl.hasAttributes()) {
+          for (let i = 0; i < itemEl.attributes.length; i++) {
+            const attr = itemEl.attributes[i];
+            itemChildrenEl.setAttribute(attr.name, attr.value);
+          }
+        }
+        itemEl.parentNode.appendChild(itemChildrenEl);
+
+        categoryContainer.appendChild(categoryEl);
+        categoryContainer.appendChild(itemEl);
+        itemEl.setAttribute('ng-if', '!suggestion.children');
+
+        $templateCache.put('category-tmpl', categoryContainer.innerHTML);
+        tElement.html(categoryContainer.outerHTML);
+      } else if (itemEl) {
+        itemEl.setAttribute('ng-repeat', 'suggestion in omnibox.suggestions');
+        tElement.html(itemEl.outerHTML);
+      }
 
       return {
         pre(scope, iElement, iAttrs, omnibox) {

--- a/src/angularComponent/ngcOmniboxSuggestionsDirective.js
+++ b/src/angularComponent/ngcOmniboxSuggestionsDirective.js
@@ -54,7 +54,6 @@ export default function ngcOmniboxSuggestionsDirective($document, $templateCache
       categoryEl.setAttribute('ng-if', 'suggestion.children');
 
       const itemChildrenEl = doc.createElement('div');
-      itemChildrenEl.setAttribute('ngc-omnibox-suggestion-item', '');
       itemChildrenEl.setAttribute('ng-repeat', 'suggestion in suggestion.children');
       itemChildrenEl.setAttribute('ng-include', `'${templateCacheName}'`);
       if (itemEl.hasAttributes()) {
@@ -63,7 +62,6 @@ export default function ngcOmniboxSuggestionsDirective($document, $templateCache
           itemChildrenEl.setAttribute(attr.name, attr.value);
         }
       }
-      itemChildrenEl.removeAttribute('ngc-omnibox-suggestion-item');
       itemEl.parentNode.appendChild(itemChildrenEl);
 
       categoryContainer.appendChild(categoryEl);

--- a/src/angularComponent/ngcOmniboxSuggestionsDirective.js
+++ b/src/angularComponent/ngcOmniboxSuggestionsDirective.js
@@ -63,6 +63,7 @@ export default function ngcOmniboxSuggestionsDirective($document, $templateCache
           itemChildrenEl.setAttribute(attr.name, attr.value);
         }
       }
+      itemChildrenEl.removeAttribute('ngc-omnibox-suggestion-item');
       itemEl.parentNode.appendChild(itemChildrenEl);
 
       categoryContainer.appendChild(categoryEl);


### PR DESCRIPTION
This allows us to provide support for recursive rendering of items and categories. In order to support this, we're making a few changes to the API:
- The app maker no longer provides their own ng-repeat directive. We do this internally now. We provide access to a "suggestion" on the scope of a suggestion item which gives them access to their data.
- When rendering categories, we're now requiring a specific data format. Any sub-children of a category must be in a `children` array, and the data passed to the source function itself must also be an array of objects.

I've also stopped using lodash in the example to make @onlywei happy. Doing the categorizing loops by hand instead.