### PR TITLE
Fix keyboard highlight interaction by making a flattened UI array

### DIFF
--- a/examples/category-results-materialize.html
+++ b/examples/category-results-materialize.html
@@ -18,18 +18,22 @@
           ng-model="demo.model"
           placeholder="Enter a car make (e.g. Ford)"
           autofocus="true"
+          is-selectable="demo.isSelectable(suggestion)"
           source="demo.sourceFn(query)">
 
         <ngc-omnibox-suggestions class="collection with-header">
           <dl ngc-omnibox-suggestion-category>
             <dt class="collection-header">
-              <h5>{{suggestion.make_country}}</h5>
+              <h5 ngc-omnibox-suggestion-header class="collection-item"
+                  ng-class="{'active': omnibox.isHighlighted(suggestion)}">
+                {{suggestion.make_country}}
+              </h5>
             </dt>
             <dd>
-              <ngc-omnibox-suggestion-item class="collection-item"
+              <div ngc-omnibox-suggestion-item class="collection-item"
                   ng-class="{'active': omnibox.isHighlighted(suggestion)}">
                 {{suggestion.make_display}}
-              </ngc-omnibox-suggestion-item>
+              </div>
             </dd>
           </dl>
         </ngc-omnibox-suggestions>
@@ -59,6 +63,11 @@
           });
 
           this.model = '';
+
+          // Only allow items, and not category headers, to be selectable
+          this.isSelectable = function (item) {
+            return !item.children;
+          };
 
           this.sourceFn = function (query) {
             if (fuse && query) {

--- a/examples/category-results-materialize.html
+++ b/examples/category-results-materialize.html
@@ -19,6 +19,7 @@
           placeholder="Enter a car make (e.g. Ford)"
           autofocus="true"
           is-selectable="demo.isSelectable(suggestion)"
+          multiple="true"
           source="demo.sourceFn(query)">
 
         <ngc-omnibox-suggestions class="collection with-header">

--- a/examples/category-results.html
+++ b/examples/category-results.html
@@ -10,6 +10,7 @@
           ng-model="demo.model"
           placeholder="Enter a car make (e.g. Ford)"
           autofocus="true"
+          is-selectable="demo.isSelectable(suggestion)"
           source="demo.sourceFn(query)">
 
         <ngc-omnibox-suggestions class="collection with-header">
@@ -49,6 +50,11 @@
           });
 
           this.model = '';
+
+          // Only allow items, and not category headers, to be selectable
+          this.isSelectable = function (item) {
+            return !item.children;
+          };
 
           this.sourceFn = function (query) {
             if (fuse && query) {

--- a/spec/tests/angularComponent/ngcModifySuggestionsTemplateSpec.js
+++ b/spec/tests/angularComponent/ngcModifySuggestionsTemplateSpec.js
@@ -12,14 +12,15 @@ const unCategorizedTemplate = [
 
 const unCategorizedTemplateOutput = [
   '<ngc-omnibox-suggestion-item ng-repeat="suggestion in omnibox.suggestions" ',
-      'suggestion="suggestion">',
+      'suggestion="suggestion" ng-attr-aria-selected="{{suggestionItem.isHighlighted()}}" ',
+      'ng-attr-aria-readonly="{{!suggestionItem.isSelectable() || undefined}}">',
     '{{suggestion.sample_item_text}}',
   '</ngc-omnibox-suggestion-item>'
 ].join('');
 
 const categorizedTemplate = [
   '<div ngc-omnibox-suggestion-category>',
-    '<h5>{{suggestion.sample_category_title}}</h5>',
+    '<h5 ngc-omnibox-suggestion-header>{{suggestion.sample_category_title}}</h5>',
     '<ngc-omnibox-suggestion-item>',
       '{{suggestion.sample_item_text}}',
     '</ngc-omnibox-suggestion-item>',
@@ -29,10 +30,16 @@ const categorizedTemplate = [
 const categorizedTemplateOutput = [
   '<div ng-repeat="suggestion in suggestion.children || omnibox.suggestions">',
     '<div ngc-omnibox-suggestion-category="" ng-if="suggestion.children">',
-      '<h5>{{suggestion.sample_category_title}}</h5>',
+      '<h5 ngc-omnibox-suggestion-header="" suggestion="suggestion" ',
+          'ng-attr-aria-selected="{{suggestionItem.isHighlighted()}}" ',
+          'ng-attr-aria-readonly="{{!suggestionItem.isSelectable() || undefined}}">',
+        '{{suggestion.sample_category_title}}',
+      '</h5>',
       '<div ng-repeat="suggestion in suggestion.children" ng-include="\'category-tmpl\'"></div>',
     '</div>',
-    '<ngc-omnibox-suggestion-item ng-if="!suggestion.children" suggestion="suggestion">',
+    '<ngc-omnibox-suggestion-item ng-if="!suggestion.children" suggestion="suggestion" ',
+        'ng-attr-aria-selected="{{suggestionItem.isHighlighted()}}" ',
+        'ng-attr-aria-readonly="{{!suggestionItem.isSelectable() || undefined}}">',
       '{{suggestion.sample_item_text}}',
     '</ngc-omnibox-suggestion-item>',
   '</div>'

--- a/spec/tests/angularComponent/ngcModifySuggestionsTemplateSpec.js
+++ b/spec/tests/angularComponent/ngcModifySuggestionsTemplateSpec.js
@@ -13,7 +13,7 @@ const unCategorizedTemplate = [
 const unCategorizedTemplateOutput = [
   '<ngc-omnibox-suggestion-item ng-repeat="suggestion in omnibox.suggestions" ',
       'suggestion="suggestion" ng-attr-aria-selected="{{suggestionItem.isHighlighted()}}" ',
-      'ng-attr-aria-readonly="{{!suggestionItem.isSelectable() || undefined}}">',
+      'ng-attr-aria-readonly="{{suggestionItem.isSelectable() === false || undefined}}">',
     '{{suggestion.sample_item_text}}',
   '</ngc-omnibox-suggestion-item>'
 ].join('');
@@ -32,14 +32,14 @@ const categorizedTemplateOutput = [
     '<div ngc-omnibox-suggestion-category="" ng-if="suggestion.children">',
       '<h5 ngc-omnibox-suggestion-header="" suggestion="suggestion" ',
           'ng-attr-aria-selected="{{suggestionItem.isHighlighted()}}" ',
-          'ng-attr-aria-readonly="{{!suggestionItem.isSelectable() || undefined}}">',
+          'ng-attr-aria-readonly="{{suggestionItem.isSelectable() === false || undefined}}">',
         '{{suggestion.sample_category_title}}',
       '</h5>',
       '<div ng-repeat="suggestion in suggestion.children" ng-include="\'category-tmpl\'"></div>',
     '</div>',
     '<ngc-omnibox-suggestion-item ng-if="!suggestion.children" suggestion="suggestion" ',
         'ng-attr-aria-selected="{{suggestionItem.isHighlighted()}}" ',
-        'ng-attr-aria-readonly="{{!suggestionItem.isSelectable() || undefined}}">',
+        'ng-attr-aria-readonly="{{suggestionItem.isSelectable() === false || undefined}}">',
       '{{suggestion.sample_item_text}}',
     '</ngc-omnibox-suggestion-item>',
   '</div>'

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -8,6 +8,7 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
     omniboxController = new NgcOmniboxController();
     omniboxController._suggestionElements = [fakeEl, fakeEl, fakeEl, fakeEl];
+    omniboxController.isSelectable = () => true;
   });
 
   describe('when determining if there are suggestions', () => {
@@ -49,7 +50,8 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
   describe('when navigating via the keyboard', () => {
     it('should highlight the next suggestion', () => {
-      ['test', 'me'].forEach((item) => omniboxController.registerItem(item));
+      omniboxController.suggestions = ['test', 'me'];
+      omniboxController._buildSuggestionsUiList();
 
       expect(omniboxController.highlightedIndex).toBe(-1);
 
@@ -61,7 +63,8 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should highlight the previous suggestion', () => {
-      ['test', 'me', 'too'].forEach((item) => omniboxController.registerItem(item));
+      omniboxController.suggestions = ['test', 'me', 'too'];
+      omniboxController._buildSuggestionsUiList();
 
       omniboxController.highlightedIndex = 1;
 
@@ -70,7 +73,8 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should wrap around the selection', () => {
-      ['test', 'me', 'again', 'please'].forEach((item) => omniboxController.registerItem(item));
+      omniboxController.suggestions = ['test', 'me', 'again', 'please'];
+      omniboxController._buildSuggestionsUiList();
       omniboxController.highlightedIndex = 0;
 
       omniboxController.highlightPrevious();

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -51,7 +51,6 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
   describe('when navigating via the keyboard', () => {
     it('should highlight the next suggestion', () => {
       omniboxController.suggestions = ['test', 'me'];
-      omniboxController._buildSuggestionsUiList();
 
       expect(omniboxController.highlightedIndex).toBe(-1);
 
@@ -64,7 +63,6 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
     it('should highlight the previous suggestion', () => {
       omniboxController.suggestions = ['test', 'me', 'too'];
-      omniboxController._buildSuggestionsUiList();
 
       omniboxController.highlightedIndex = 1;
 
@@ -74,7 +72,6 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
     it('should wrap around the selection', () => {
       omniboxController.suggestions = ['test', 'me', 'again', 'please'];
-      omniboxController._buildSuggestionsUiList();
       omniboxController.highlightedIndex = 0;
 
       omniboxController.highlightPrevious();

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -8,7 +8,7 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
     omniboxController = new NgcOmniboxController();
     omniboxController._suggestionElements = [fakeEl, fakeEl, fakeEl, fakeEl];
-    omniboxController.isSelectable = () => true;
+    omniboxController.isSelectable = () => {};
   });
 
   describe('when determining if there are suggestions', () => {

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -48,6 +48,40 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
   });
 
+  describe('building a flattened list representation of the suggestions', () => {
+    it('should produce a list of UI objects with strings for data', () => {
+      omniboxController.suggestions = ['test', 'me', 'now'];
+      expect(JSON.stringify(omniboxController._suggestionsUiList)).toBe(JSON.stringify([
+        {index: 0, data: 'test'},
+        {index: 1, data: 'me'},
+        {index: 2, data: 'now'}
+      ]));
+    });
+
+    it('should product a flat list of UI objects from a nested list of suggestions', () => {
+      omniboxController.suggestions = [
+        {title: 'test', children: ['one', 'two', 'three']},
+        {title: 'me', children: ['four', 'five', 'six']},
+        {title: 'now', children: ['seven', 'eight', 'nine']}
+      ];
+
+      expect(JSON.stringify(omniboxController._suggestionsUiList)).toBe(JSON.stringify([
+        {index: 0, data: {title: 'test', children: ['one', 'two', 'three']}},
+        {index: 1, data: 'one'},
+        {index: 2, data: 'two'},
+        {index: 3, data: 'three'},
+        {index: 4, data: {title: 'me', children: ['four', 'five', 'six']}},
+        {index: 5, data: 'four'},
+        {index: 6, data: 'five'},
+        {index: 7, data: 'six'},
+        {index: 8, data: {title: 'now', children: ['seven', 'eight', 'nine']}},
+        {index: 9, data: 'seven'},
+        {index: 10, data: 'eight'},
+        {index: 11, data: 'nine'}
+      ]));
+    });
+  });
+
   describe('when navigating via the keyboard', () => {
     it('should highlight the next suggestion', () => {
       omniboxController.suggestions = ['test', 'me'];

--- a/src/angularComponent/ngcModifySuggestionsTemplateFactory.js
+++ b/src/angularComponent/ngcModifySuggestionsTemplateFactory.js
@@ -32,24 +32,35 @@ export default function ngcModifySuggestionsTemplateFactory($document, $template
       const itemChildrenEl = doc.createElement('div');
       itemChildrenEl.setAttribute('ng-repeat', 'suggestion in suggestion.children');
       itemChildrenEl.setAttribute('ng-include', `'${templateCacheName}'`);
-      if (itemEl.hasAttributes()) {
-        for (let i = 0; i < itemEl.attributes.length; i++) {
-          const attr = itemEl.attributes[i];
-          itemChildrenEl.setAttribute(attr.name, attr.value);
-        }
-      }
+
       itemEl.parentNode.appendChild(itemChildrenEl);
+
+      const itemHeader = element.querySelector(
+        'ngc-omnibox-suggestion-header, [ngc-omnibox-suggestion-header]'
+      );
+      if (itemHeader) {
+        itemHeader.setAttribute('suggestion', 'suggestion');
+        itemHeader.setAttribute('ng-attr-aria-selected', '{{suggestionItem.isHighlighted()}}');
+        itemHeader.setAttribute('ng-attr-aria-readonly',
+            '{{!suggestionItem.isSelectable() || undefined}}');
+      }
 
       categoryContainer.appendChild(categoryEl);
       categoryContainer.appendChild(itemEl);
       itemEl.setAttribute('ng-if', '!suggestion.children');
       itemEl.setAttribute('suggestion', 'suggestion');
+      itemEl.setAttribute('ng-attr-aria-selected', '{{suggestionItem.isHighlighted()}}');
+      itemEl.setAttribute('ng-attr-aria-readonly',
+          '{{!suggestionItem.isSelectable() || undefined}}');
 
       $templateCache.put(templateCacheName, categoryContainer.innerHTML);
       return categoryContainer.outerHTML;
     } else if (itemEl) {
       itemEl.setAttribute('ng-repeat', 'suggestion in omnibox.suggestions');
       itemEl.setAttribute('suggestion', 'suggestion');
+      itemEl.setAttribute('ng-attr-aria-selected', '{{suggestionItem.isHighlighted()}}');
+      itemEl.setAttribute('ng-attr-aria-readonly',
+          '{{!suggestionItem.isSelectable() || undefined}}');
       return itemEl.outerHTML;
     } else {
       throw new Error('An ngcOmniboxSuggestionItem is required.');

--- a/src/angularComponent/ngcModifySuggestionsTemplateFactory.js
+++ b/src/angularComponent/ngcModifySuggestionsTemplateFactory.js
@@ -42,7 +42,7 @@ export default function ngcModifySuggestionsTemplateFactory($document, $template
         itemHeader.setAttribute('suggestion', 'suggestion');
         itemHeader.setAttribute('ng-attr-aria-selected', '{{suggestionItem.isHighlighted()}}');
         itemHeader.setAttribute('ng-attr-aria-readonly',
-            '{{!suggestionItem.isSelectable() || undefined}}');
+            '{{suggestionItem.isSelectable() === false || undefined}}');
       }
 
       categoryContainer.appendChild(categoryEl);
@@ -51,7 +51,7 @@ export default function ngcModifySuggestionsTemplateFactory($document, $template
       itemEl.setAttribute('suggestion', 'suggestion');
       itemEl.setAttribute('ng-attr-aria-selected', '{{suggestionItem.isHighlighted()}}');
       itemEl.setAttribute('ng-attr-aria-readonly',
-          '{{!suggestionItem.isSelectable() || undefined}}');
+          '{{suggestionItem.isSelectable() === false || undefined}}');
 
       $templateCache.put(templateCacheName, categoryContainer.innerHTML);
       return categoryContainer.outerHTML;
@@ -60,7 +60,7 @@ export default function ngcModifySuggestionsTemplateFactory($document, $template
       itemEl.setAttribute('suggestion', 'suggestion');
       itemEl.setAttribute('ng-attr-aria-selected', '{{suggestionItem.isHighlighted()}}');
       itemEl.setAttribute('ng-attr-aria-readonly',
-          '{{!suggestionItem.isSelectable() || undefined}}');
+          '{{suggestionItem.isSelectable() === false || undefined}}');
       return itemEl.outerHTML;
     } else {
       throw new Error('An ngcOmniboxSuggestionItem is required.');

--- a/src/angularComponent/ngcOmnibox.html
+++ b/src/angularComponent/ngcOmnibox.html
@@ -1,6 +1,6 @@
 <input type="text" role="combobox" aria-autocomplete="list"
     ng-attr-aria-expanded="{{omnibox.hasSuggestions()}}"
-    ng-model="omnibox.ngModel"
+    ng-model="omnibox.query"
     ng-change="omnibox.onInputChange()"
     ng-keydown="omnibox.onKeyDown($event)"
     ng-keyup="omnibox.onKeyUp($event)"

--- a/src/angularComponent/ngcOmniboxComponent.js
+++ b/src/angularComponent/ngcOmniboxComponent.js
@@ -15,6 +15,7 @@ export default {
     autofocus: '@',
     ngDisabled: '&',
     isSelectable: '&',
+    multiple: '<',
     source: '&'
   }
 };

--- a/src/angularComponent/ngcOmniboxComponent.js
+++ b/src/angularComponent/ngcOmniboxComponent.js
@@ -14,6 +14,7 @@ export default {
     placeholder: '@',
     autofocus: '@',
     ngDisabled: '&',
+    isSelectable: '&',
     source: '&'
   }
 };

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -92,7 +92,7 @@ export default class NgcOmniboxController {
 
     const suggestion = this._suggestionsUiList[newIndex];
     if (this.isSelectable({suggestion: suggestion.data}) === false) {
-      if (startHighlightIndex === null || typeof startHighlightIndex === 'undefined') {
+      if (typeof startHighlightIndex !== 'number') {
         startHighlightIndex = newIndex;
       }
 
@@ -129,7 +129,7 @@ export default class NgcOmniboxController {
 
     const suggestion = this._suggestionsUiList[newIndex];
     if (this.isSelectable({suggestion: suggestion.data}) === false) {
-      if (startHighlightIndex === null || typeof startHighlightIndex === 'undefined') {
+      if (typeof startHighlightIndex !== 'number') {
         startHighlightIndex = newIndex;
       }
 

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -32,7 +32,7 @@ export default class NgcOmniboxController {
 
     if (this.hasSuggestions()) {
 
-      if (isVerticalMovementKey(keyCode)) {
+      if (isVerticalMovementKey(keyCode) || isSelectKey(keyCode)) {
         $event.preventDefault();
         $event.stopPropagation();
       }
@@ -45,14 +45,9 @@ export default class NgcOmniboxController {
     }
   }
 
-  onKeyUp($event) {
+  onKeyUp() {
     this.$timeout.cancel(this._keyDownTimeout);
     this._keyDownTimeout = null;
-
-    if (this.hasSuggestions() && isSelectKey($event.which)) {
-      const selection = this._suggestionsUiList[this.highlightedIndex];
-      selection && this._selectItem(selection.data);
-    }
   }
 
   /**
@@ -168,6 +163,9 @@ export default class NgcOmniboxController {
       this.highlightNext();
     } else if (keyCode === KEY.ESC) {
       this.highlightNone();
+    } else if (isSelectKey(keyCode)) {
+      const selection = this._suggestionsUiList[this.highlightedIndex];
+      selection && this._selectItem(selection.data);
     }
   }
 

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -1,4 +1,4 @@
-import {KEY, isVerticalMovementKey} from '../coreComponent/keyboard.js';
+import {KEY, isSelectKey, isVerticalMovementKey} from '../coreComponent/keyboard.js';
 
 // Protects against multiple key events firing in a row without disallowing holding down the key
 const KEY_REPEAT_DELAY = 150;
@@ -45,9 +45,14 @@ export default class NgcOmniboxController {
     }
   }
 
-  onKeyUp() {
+  onKeyUp($event) {
     this.$timeout.cancel(this._keyDownTimeout);
     this._keyDownTimeout = null;
+
+    if (this.hasSuggestions() && isSelectKey($event.which)) {
+      const selection = this._suggestionsUiList[this.highlightedIndex];
+      selection && this._selectItem(selection.data);
+    }
   }
 
   /**
@@ -201,6 +206,10 @@ export default class NgcOmniboxController {
   }
 
   _selectItem(item) {
+    if (!item) {
+      return null;
+    }
+
     if (this.multiple) {
       this.ngModel = this.ngModel || [];
       this.ngModel.push(item);

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -116,7 +116,8 @@ export default class NgcOmniboxController {
   }
 
   isHighlighted(item) {
-    return this._suggestionItems.indexOf(item) === this.highlightedIndex;
+    const index = this._suggestionItems.indexOf(item);
+    return index >= 0 && index === this.highlightedIndex;
   }
 
   _handleKeyDown(keyCode) {

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -185,7 +185,6 @@ export default class NgcOmniboxController {
     this.source({query: this.query}).then((suggestions) => {
       if (suggestions) {
         this.suggestions = Array.prototype.slice.apply(suggestions);
-        this._buildSuggestionsUiList();
       } else {
         throw new Error('Suggestions must be an Array');
       }

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -69,9 +69,11 @@ export default class NgcOmniboxController {
    * Tries to update the index of the currently highlighted item to be the next item in the list. If
    * we've reached the end, it'll loop back around and highlight the first item.
    *
+   * @param {Number} startHighlightIndex -- If running this function recursively, this is the index
+   *     that was used at the start. This is to prevent it running infinitely.
    * @returns {Number} -- Index of the newly highlighted item
    */
-  highlightPrevious() {
+  highlightPrevious(startHighlightIndex) {
     let newIndex = this.highlightedIndex;
 
     if (newIndex > 0) {
@@ -81,7 +83,7 @@ export default class NgcOmniboxController {
     }
 
     // Protect against an infinite loop in cases where all items are disabled
-    if (this.startHighlightIndex === newIndex) {
+    if (startHighlightIndex === newIndex) {
       this.highlightNone();
       return this.highlightedIndex;
     } else {
@@ -90,13 +92,11 @@ export default class NgcOmniboxController {
 
     const suggestion = this._suggestionsUiList[newIndex];
     if (this.isSelectable({suggestion: suggestion.data}) === false) {
-      if (this.startHighlightIndex === null || typeof this.startHighlightIndex === 'undefined') {
-        this.startHighlightIndex = newIndex;
+      if (startHighlightIndex === null || typeof startHighlightIndex === 'undefined') {
+        startHighlightIndex = newIndex;
       }
 
-      this.highlightPrevious();
-    } else {
-      this.startHighlightIndex = null;
+      this.highlightPrevious(startHighlightIndex);
     }
 
     return newIndex;
@@ -106,9 +106,11 @@ export default class NgcOmniboxController {
    * Tries to update the index of the currently highlighted item to be the previous item in the
    * list. If we've reached the starrt, it'll loop back and highlight the last item.
    *
+   * @param {Number} startHighlightIndex -- If running this function recursively, this is the index
+   *     that was used at the start. This is to prevent it running infinitely.
    * @returns {Number} -- Index of the newly highlighted item
    */
-  highlightNext() {
+  highlightNext(startHighlightIndex) {
     let newIndex = this.highlightedIndex;
 
     if (newIndex < this._suggestionsUiList.length - 1) {
@@ -118,7 +120,7 @@ export default class NgcOmniboxController {
     }
 
     // Protect against an infinite loop in cases where all items are disabled
-    if (this.startHighlightIndex === newIndex) {
+    if (startHighlightIndex === newIndex) {
       this.highlightNone();
       return this.highlightedIndex;
     } else {
@@ -127,13 +129,11 @@ export default class NgcOmniboxController {
 
     const suggestion = this._suggestionsUiList[newIndex];
     if (this.isSelectable({suggestion: suggestion.data}) === false) {
-      if (this.startHighlightIndex === null || typeof this.startHighlightIndex === 'undefined') {
-        this.startHighlightIndex = newIndex;
+      if (startHighlightIndex === null || typeof startHighlightIndex === 'undefined') {
+        startHighlightIndex = newIndex;
       }
 
-      this.highlightNext();
-    } else {
-      this.startHighlightIndex = null;
+      this.highlightNext(startHighlightIndex);
     }
 
     return newIndex;

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -89,7 +89,7 @@ export default class NgcOmniboxController {
     }
 
     const suggestion = this._suggestionsUiList[newIndex];
-    if (!this.isSelectable({suggestion: suggestion.data})) {
+    if (this.isSelectable({suggestion: suggestion.data}) === false) {
       if (this.startHighlightIndex === null || typeof this.startHighlightIndex === 'undefined') {
         this.startHighlightIndex = newIndex;
       }
@@ -126,7 +126,7 @@ export default class NgcOmniboxController {
     }
 
     const suggestion = this._suggestionsUiList[newIndex];
-    if (!this.isSelectable({suggestion: suggestion.data})) {
+    if (this.isSelectable({suggestion: suggestion.data}) === false) {
       if (this.startHighlightIndex === null || typeof this.startHighlightIndex === 'undefined') {
         this.startHighlightIndex = newIndex;
       }

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -178,9 +178,21 @@ export default class NgcOmniboxController {
         this.suggestions = Array.prototype.slice.apply(suggestions);
         this._buildSuggestionsUiList();
       } else {
-        this.suggestions = suggestions;
+        throw new Error('Suggestions must be an Array');
       }
     });
+  }
+
+  set suggestions(suggestions) {
+    this._suggestions = suggestions;
+
+    if (Array.isArray(suggestions)) {
+      this._buildSuggestionsUiList();
+    }
+  }
+
+  get suggestions() {
+    return this._suggestions;
   }
 
   /**

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -16,7 +16,7 @@ export default class NgcOmniboxController {
     // Flatttened list of elements in the order they appear in the UI
     this._suggestionsUiList = [];
 
-    this.highlightedIndex = -1; // -1 means nothing is highlighted
+    this.highlightNone();
   }
 
   $postLink() {
@@ -87,6 +87,7 @@ export default class NgcOmniboxController {
 
     // Protect against an infinite loop in cases where all items are disabled
     if (this.startHighlightIndex === newIndex) {
+      this.highlightNone();
       return this.highlightedIndex;
     } else {
       this.highlightedIndex = newIndex;
@@ -123,6 +124,7 @@ export default class NgcOmniboxController {
 
     // Protect against an infinite loop in cases where all items are disabled
     if (this.startHighlightIndex === newIndex) {
+      this.highlightNone();
       return this.highlightedIndex;
     } else {
       this.highlightedIndex = newIndex;
@@ -142,6 +144,13 @@ export default class NgcOmniboxController {
     return newIndex;
   }
 
+  /**
+   * Un-highlights all suggestions.
+   */
+  highlightNone() {
+    this.highlightedIndex = -1; // -1 means nothing is highlighted
+  }
+
   isHighlighted(item) {
     const match = this._suggestionsUiList.find((listItem) => listItem.data === item);
 
@@ -158,13 +167,13 @@ export default class NgcOmniboxController {
     } else if (keyCode === KEY.DOWN) {
       this.highlightNext();
     } else if (keyCode === KEY.ESC) {
-      this.highlightedIndex = -1;
+      this.highlightNone();
     }
   }
 
   _updateSuggestions() {
     this._suggestionsUiList.length = 0;
-    this.highlightedIndex = -1;
+    this.highlightNone();
 
     this.source({query: this.query}).then((suggestions) => {
       if (suggestions) {

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -184,7 +184,7 @@ export default class NgcOmniboxController {
 
     this.source({query: this.query}).then((suggestions) => {
       if (suggestions) {
-        this.suggestions = Array.prototype.slice.apply(suggestions);
+        this.suggestions = suggestions;
       } else {
         throw new Error('Suggestions must be an Array');
       }
@@ -192,9 +192,8 @@ export default class NgcOmniboxController {
   }
 
   set suggestions(suggestions) {
-    this._suggestions = suggestions;
-
     if (Array.isArray(suggestions)) {
+      this._suggestions = Array.prototype.slice.apply(suggestions);
       this._buildSuggestionsUiList();
     }
   }

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -146,14 +146,23 @@ export default class NgcOmniboxController {
     this.highlightedIndex = -1; // -1 means nothing is highlighted
   }
 
-  isHighlighted(item) {
-    const match = this._suggestionsUiList.find((listItem) => listItem.data === item);
+  set highlightedIndex(index) {
+    this._highlightedIndex = index;
 
-    if (match) {
-      return match.index >= 0 && match.index === this.highlightedIndex;
+    const highlightedUiItem = this._suggestionsUiList[index];
+    if (highlightedUiItem) {
+      this._highlightedItem = highlightedUiItem.data;
     } else {
-      return false;
+      this._highlightedItem = null;
     }
+  }
+
+  get highlightedIndex() {
+    return this._highlightedIndex;
+  }
+
+  isHighlighted(item) {
+    return item === this._highlightedItem;
   }
 
   _handleKeyDown(keyCode) {

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -133,8 +133,17 @@ export default class NgcOmniboxController {
     this._suggestionItems.length = 0;
     this.highlightedIndex = -1;
 
-    this.source({query: this.ngModel}).then((suggestions) => {
+    this.source({query: this.query}).then((suggestions) => {
       this.suggestions = suggestions;
     });
+  }
+
+  _selectItem(item) {
+    if (this.multiple) {
+      this.ngModel = this.ngModel || [];
+      this.ngModel.push(item);
+    } else {
+      this.ngModel = item;
+    }
   }
 }

--- a/src/angularComponent/ngcOmniboxSuggestionItemController.js
+++ b/src/angularComponent/ngcOmniboxSuggestionItemController.js
@@ -1,9 +1,20 @@
 export default class NgcOmniboxSuggestionItemController {
-  $onInit() {
-    this.omnibox.registerItem(this.suggestion);
 
+  /**
+   * Whether or not the item is currently highlighted.
+   *
+   * @returns {Boolean}
+   */
+  isHighlighted() {
+    return this.omnibox.isHighlighted(this.suggestion);
   }
-  $onDestroy() {
-    this.omnibox.deregisterItem(this.index);
+
+  /**
+   * Whether or not the item is currently selectable by the keyboard or mouse.
+   *
+   * @returns {Boolean}
+   */
+  isSelectable() {
+    return this.omnibox.isSelectable({suggestion: this.suggestion});
   }
 }

--- a/src/coreComponent/keyboard.js
+++ b/src/coreComponent/keyboard.js
@@ -176,7 +176,13 @@ export function isFunctionKey(keyCode) {
  * @returns {Boolean}
  */
 export function isVerticalMovementKey(keyCode) {
-  return [KEY.UP, KEY.DOWN].includes(keyCode);
+  switch (keyCode) {
+    case KEY.UP:
+    case KEY.DOWN:
+      return true;
+  }
+
+  return false;
 }
 
 /**
@@ -186,7 +192,15 @@ export function isVerticalMovementKey(keyCode) {
  * @returns {Boolean}
  */
 export function isHorizontalMovementKey(keyCode) {
-  return [KEY.LEFT, KEY.RIGHT, KEY.BACKSPACE, KEY.DELETE].includes(keyCode);
+  switch (keyCode) {
+    case KEY.LEFT:
+    case KEY.RIGHT:
+    case KEY.BACKSPACE:
+    case KEY.DELETE:
+      return true;
+  }
+
+  return false;
 }
 
 /**
@@ -196,5 +210,11 @@ export function isHorizontalMovementKey(keyCode) {
  * @returns {Boolean}
  */
 export function isSelectKey(keyCode) {
-  return [KEY.ENTER, KEY.TAB].includes(keyCode);
+  switch (keyCode) {
+    case KEY.ENTER:
+    case KEY.TAB:
+      return true;
+  }
+
+  return false;
 }

--- a/src/coreComponent/keyboard.js
+++ b/src/coreComponent/keyboard.js
@@ -188,3 +188,13 @@ export function isVerticalMovementKey(keyCode) {
 export function isHorizontalMovementKey(keyCode) {
   return [KEY.LEFT, KEY.RIGHT, KEY.BACKSPACE, KEY.DELETE].includes(keyCode);
 }
+
+/**
+ * Returns true if pressing this key should select a highlighted item.
+ *
+ * @param {Number} keyCode
+ * @returns {Boolean}
+ */
+export function isSelectKey(keyCode) {
+  return [KEY.ENTER, KEY.TAB].includes(keyCode);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,5 +9,6 @@ export default angular.module('ngc.omnibox', [])
   .component('ngcOmnibox', ngcOmniboxComponent)
   .factory('ngcModifySuggestionsTemplate', ngcModifySuggestionsTemplateFactory)
   .directive('ngcOmniboxSuggestions', ngcOmniboxSuggestionsDirective)
+  .directive('ngcOmniboxSuggestionHeader', ngcOmniboxSuggestionItemDirective)
   .directive('ngcOmniboxSuggestionItem', ngcOmniboxSuggestionItemDirective)
   .name;


### PR DESCRIPTION
Also add a new &-bound callback binding on `ngc-omnibox` called `isSelectable`. `isSelectable` has access to a `suggestion` value in its expression which is a single suggestion object. If this expression returns true, then an item can be interacted with via keyboard and mouse. If it returns false, it cannot.

This can be used to disable selecting category headers, as well as just figuring out if individual items should be disabled.