### PR TITLE
Add hideOnBlur binding to main component

### DIFF
--- a/src/angularComponent/ngcOmniboxComponent.js
+++ b/src/angularComponent/ngcOmniboxComponent.js
@@ -7,6 +7,7 @@ export default {
     ngModel: '=',
     placeholder: '@',
     autofocus: '@',
+    hideOnBlur: '@',
     ngDisabled: '&',
     isSelectable: '&',
     canShow: '&',

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -54,16 +54,18 @@ export default class NgcOmniboxController {
       $scope.$apply();
     });
 
-    let blurTimeout;
-    this.element.addEventListener('focus', () => {
-      clearTimeout(blurTimeout);
-    }, true);
-    this.element.addEventListener('blur', () => {
-      blurTimeout = setTimeout(() => {
-        this.hideSuggestions = true;
-        $scope.$apply();
-      }, SUGGESTIONS_BLUR_THRESHOLD);
-    }, true);
+    if (this.hideOnBlur !== 'false') {
+      let blurTimeout;
+      this.element.addEventListener('focus', () => {
+        clearTimeout(blurTimeout);
+      }, true);
+      this.element.addEventListener('blur', () => {
+        blurTimeout = setTimeout(() => {
+          this.hideSuggestions = true;
+          $scope.$apply();
+        }, SUGGESTIONS_BLUR_THRESHOLD);
+      }, true);
+    }
 
     // Remove the focus ring when the overall component is focused
     const styleSheets = this.doc.styleSheets;


### PR DESCRIPTION
If the `hide-on-blur` binding is explicitly set to false, then losing focus on the omnibox or clicking outside it won't automatically hide the suggestions. This option is evaluated once on startup.