### PR TITLE
Update ngModel's existing prototype instead of assuming Array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -125,8 +125,8 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
   describe('suggestion visibility', () => {
     beforeEach(() => {
+      omniboxController.suggestions = null;
       omniboxController.shouldShowLoadingElement = false;
-      omniboxController.hasSuggestions = false;
       omniboxController.canShowSuggestions = () => false;
     });
 
@@ -140,7 +140,7 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     it('should not be determined by just the presence of suggestions', () => {
       expect(omniboxController.shouldShowSuggestions()).toBe(false);
 
-      omniboxController.hasSuggestions = true;
+      omniboxController.suggestions = [];
       expect(omniboxController.shouldShowSuggestions()).toBe(false);
     });
 
@@ -153,14 +153,14 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
     it('should be determined by loading state, having suggestions, and can-show binding', () => {
       omniboxController.shouldShowLoadingElement = true;
-      omniboxController.hasSuggestions = true;
+      omniboxController.suggestions = [];
       omniboxController.canShowSuggestions = () => true;
       expect(omniboxController.shouldShowSuggestions()).toBe(true);
     });
 
     it('should be visible when done loading if has suggestions and can-show passes', () => {
       omniboxController.shouldShowLoadingElement = false;
-      omniboxController.hasSuggestions = true;
+      omniboxController.suggestions = [];
       omniboxController.canShowSuggestions = () => true;
       expect(omniboxController.shouldShowSuggestions()).toBe(true);
     });

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -9,8 +9,6 @@ const LOADING_SCREEN_THRESHOLD = 150;
 // Time in miliseconds to wait before closing the suggestions after focus is lost
 const SUGGESTIONS_BLUR_THRESHOLD = 10;
 
-const customArrayPrototype = Object.create(Array.prototype);
-
 export default class NgcOmniboxController {
   static get $inject() {
     return ['$document', '$element', '$scope'];
@@ -31,16 +29,6 @@ export default class NgcOmniboxController {
     this.shouldShowLoadingElement = false; // Been loading for long enough we should show loading UI
 
     this.highlightNone();
-
-    // Listen for updates to the model when it's an array
-    const omnibox = this;
-    ['push', 'pop', 'shift', 'unshift', 'splice'].forEach((property) => {
-      customArrayPrototype[property] = function (...args) {
-        const ret = Array.prototype[property].apply(this, args);
-        omnibox._onNgModelChange();
-        return ret;
-      };
-    });
 
     // Need our overall component to be focusable so that it can continue listening to keyboard
     // events when we stop focusing on the input field and focus on the choices
@@ -104,7 +92,19 @@ export default class NgcOmniboxController {
     this._ngModel = newModel;
 
     if (Array.isArray(this._ngModel)) {
-      Object.setPrototypeOf(this._ngModel, customArrayPrototype);
+      const currentPrototype = Object.getPrototypeOf(this._ngModel);
+      const newPrototype = Object.create(currentPrototype);
+      Object.setPrototypeOf(this._ngModel, newPrototype);
+
+      // Listen for updates to the model when it's an array
+      const omnibox = this;
+      ['push', 'pop', 'shift', 'unshift', 'splice'].forEach((property) => {
+        newPrototype[property] = function (...args) {
+          const ret = currentPrototype[property].apply(this, args);
+          omnibox._onNgModelChange();
+          return ret;
+        };
+      });
     }
 
     this._onNgModelChange();

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -94,7 +94,6 @@ export default class NgcOmniboxController {
     if (Array.isArray(this._ngModel)) {
       const currentPrototype = Object.getPrototypeOf(this._ngModel);
       const newPrototype = Object.create(currentPrototype);
-      Object.setPrototypeOf(this._ngModel, newPrototype);
 
       // Listen for updates to the model when it's an array
       const omnibox = this;
@@ -105,6 +104,8 @@ export default class NgcOmniboxController {
           return ret;
         };
       });
+
+      Object.setPrototypeOf(this._ngModel, newPrototype);
     }
 
     this._onNgModelChange();

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -404,7 +404,7 @@ export default class NgcOmniboxController {
    * @returns {Boolean}
    */
   shouldShowSuggestions() {
-    return !this.hideSuggestions && (this.shouldShowLoadingElement || this.hasSuggestions) &&
+    return !this.hideSuggestions && (this.shouldShowLoadingElement || !!this.suggestions) &&
         this.canShowSuggestions({query: this.query}) !== false;
   }
 


### PR DESCRIPTION
This allows better prototypal inheritance in cases where the prototype of the ngModel was already custom.