### PR TITLE
Fix digest cycle race conditions when updating suggestions

### DIFF
--- a/examples/category-results-materialize.html
+++ b/examples/category-results-materialize.html
@@ -10,7 +10,7 @@
         display: block;
       }
 
-      [ngc-omnibox-suggestions] {
+      .collection {
         position: absolute;
         top: 100%;
         left: 0;
@@ -34,7 +34,7 @@
         width: 100% !important;
         font-size: 16px; /* stops iOS Safari from zooming in */
       }
-      [ngc-omnibox-field] {
+      .omniboxField {
         flex-grow: 1;
         flex-basis: 200px;
       }
@@ -66,7 +66,7 @@
             </div>
           </div>
 
-          <div ngc-omnibox-field ng-focus="demoCtrl.fieldHasFocus = true"
+          <div class="omniboxField" ngc-omnibox-field ng-focus="demoCtrl.fieldHasFocus = true"
                 ng-blur="demoCtrl.fieldHasFocus = false">
             <input class="input" type="text" autofocus="true"
                 placeholder="Search for a US Senator by Name or Party">

--- a/examples/simple-suggest-materialize.html
+++ b/examples/simple-suggest-materialize.html
@@ -7,7 +7,7 @@
       display: block;
     }
 
-    ngc-omnibox-suggestion-item {
+    .collection-item {
       display: inline-block;
     }
   </style>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -195,7 +195,7 @@ export default class NgcOmniboxController {
         startHighlightIndex = newIndex;
       }
 
-      return  this.highlightPreviousSuggestion(startHighlightIndex);
+      return this.highlightPreviousSuggestion(startHighlightIndex);
     }
 
     this._scrollSuggestionIntoView();

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -153,6 +153,10 @@ export default class NgcOmniboxController {
   * @param {Object} item
   */
   highlightSuggestion(item) {
+    if (this.isHighlightingDisabled) {
+      return;
+    }
+
     const [uiItemMatch] = this._suggestionsUiList.filter((uiItem) => uiItem.data === item);
 
     if (uiItemMatch && this.isSelectable({suggestion: uiItemMatch.data}) !== false) {
@@ -191,7 +195,7 @@ export default class NgcOmniboxController {
         startHighlightIndex = newIndex;
       }
 
-      this.highlightPreviousSuggestion(startHighlightIndex);
+      return  this.highlightPreviousSuggestion(startHighlightIndex);
     }
 
     this._scrollSuggestionIntoView();
@@ -230,7 +234,7 @@ export default class NgcOmniboxController {
         startHighlightIndex = newIndex;
       }
 
-      this.highlightNextSuggestion(startHighlightIndex);
+      return this.highlightNextSuggestion(startHighlightIndex);
     }
 
     this._scrollSuggestionIntoView();
@@ -242,6 +246,10 @@ export default class NgcOmniboxController {
    * Un-highlights all suggestions.
    */
   highlightNone() {
+    if (this.isHighlightingDisabled) {
+      return;
+    }
+
     this.highlightedIndex = -1; // -1 means nothing is highlighted
   }
 
@@ -572,6 +580,9 @@ export default class NgcOmniboxController {
   _scrollSuggestionIntoView() {
     this.$scope.$apply();
 
+    // Disable highlighting while scrolling so the mouse doesn't accidentally highlight a new item
+    this.isHighlightingDisabled = true;
+
     // Wait until next render cycle
     setTimeout(() => {
       const selectedEl = this.element.querySelector('[aria-selected]');
@@ -586,5 +597,9 @@ export default class NgcOmniboxController {
         }
       }
     }, 0);
+
+    setTimeout(() => {
+      this.isHighlightingDisabled = false;
+    }, 10);
   }
 }

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -494,6 +494,7 @@ export default class NgcOmniboxController {
 
     this.highlightNone();
     this._showLoading();
+    this.hideSuggestions = false;
 
     const promise = this.source({query: this.query, suggestions: this.suggestions});
     this._sourceFunctionPromise = promise;
@@ -504,8 +505,6 @@ export default class NgcOmniboxController {
         return;
       }
 
-      this._hideLoading();
-
       if (!suggestions) {
         this.suggestions = null;
       } else if (Array.isArray(suggestions)) {
@@ -514,7 +513,7 @@ export default class NgcOmniboxController {
         throw new Error('Suggestions must be an Array');
       }
 
-      this.hideSuggestions = false;
+      this._hideLoading();
     });
   }
 

--- a/src/angularComponent/ngcOmniboxSuggestionItemController.js
+++ b/src/angularComponent/ngcOmniboxSuggestionItemController.js
@@ -1,7 +1,7 @@
 export default class NgcOmniboxSuggestionItemController {
 
   handleMouseEnter() {
-    this.omnibox.highlightSuggestion(this.suggestion);
+    // this.omnibox.highlightSuggestion(this.suggestion);
   }
 
   handleMouseLeave() {

--- a/src/angularComponent/ngcOmniboxSuggestionItemController.js
+++ b/src/angularComponent/ngcOmniboxSuggestionItemController.js
@@ -1,7 +1,7 @@
 export default class NgcOmniboxSuggestionItemController {
 
   handleMouseEnter() {
-    // this.omnibox.highlightSuggestion(this.suggestion);
+    this.omnibox.highlightSuggestion(this.suggestion);
   }
 
   handleMouseLeave() {

--- a/src/angularComponent/ngcOmniboxSuggestionsDirective.js
+++ b/src/angularComponent/ngcOmniboxSuggestionsDirective.js
@@ -31,7 +31,7 @@ export default function ngcOmniboxSuggestionsDirective($document, ngcModifySugge
       const doc = $document[0];
       const element = tElement[0];
       const tmpl = ngcModifySuggestionsTemplate(element);
-      const isElemDirective = element.localName === 'ngc-omnibox-suggestions';
+      const isElemDirective = element.tagName === 'NGC-OMNIBOX-SUGGESTIONS';
 
       // Wrap all of the element contents so we can put an ng-if on it. The wrapper should use
       // all the attributes passed in by the app-maker except for the directive since that would
@@ -48,9 +48,9 @@ export default function ngcOmniboxSuggestionsDirective($document, ngcModifySugge
         }
       });
 
-      // Use the same direcrive strategy (attribute or element) for the new wrapping element as
+      // Use the same directive strategy (attribute or element) for the new wrapping element as
       // the app-maker did.
-      if (element.localName === 'ngc-omnibox-suggestions') {
+      if (isElemDirective) {
         element.outerHTML = '<ngc-omnibox-suggestions>' + wrapper.outerHTML +
             '</ngc-omnibox-suggestions>';
       } else if (element.hasAttribute('ngc-omnibox-suggestions')) {


### PR DESCRIPTION
Depending on the app and how quickly your markup would get updated, sometimes when you re-opened the suggestions, you would see the old suggestions for a second until the markup was updated by Angular's digest cycle.

To combat this, we're now wrapping the contents of the suggestions directive in a wrapper so that we can use ng-if, which does a better job of syncing up the digest cycle. Since the user has control over the type of element and attributes that are applied to the suggestions directive, we also will try and honor their markup as much as possible, grabbing all the attributes from the now root suggestions element and applying them to the wrapper.