### PR TITLE
Throw an error if more than one reference of a suggestion subcomponent is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,8 @@ css classes.
 
 Omnibox Suggestions is a container for your lists of suggestions to be rendered in. It has
 additional subcomponents that allow you to slot in markup for different parts needed for the
-suggestions to render. Please note that this is the only component which **will not respect any of
-the markup you provide**. Any markup inside here that is not one of the documented subcomponents
-will be removed.
+suggestions to render. You can include at most one instance of an individual subcomponent. If you
+include more than one, an Error will be thrown.
 
 #### Omnibox Suggestion Item `<ngc-omnibox-suggestion-item>` _(Required)_
 The Suggestion Item component gives you a slot for markup for a single suggestion. This markup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/spec/tests/angularComponent/ngcModifySuggestionsTemplateFactorySpec.js
+++ b/spec/tests/angularComponent/ngcModifySuggestionsTemplateFactorySpec.js
@@ -79,4 +79,19 @@ describe('ngcOmnibox.angularComponent.ngcModifySuggestionsTemplateFactory', () =
     ngcModifySuggestionsTemplate = ngcModifySuggestionsTemplateFactory([document], templateCache);
     expect(ngcModifySuggestionsTemplate(element, 'category-tmpl')).toBe(categorizedTemplateOutput);
   });
+
+  it('should only allow one instance of a subcomponent', () => {
+    const elementTemplate = `
+      <ngc-omnibox-suggestions>
+        <ngc-omnibox-suggestion-item></ngc-omnibox-suggestion-item>
+        <ngc-omnibox-suggestion-item></ngc-omnibox-suggestion-item>
+      </ngc-omnibox-suggestions>
+    `;
+    const document = jsdom.jsdom(elementTemplate).defaultView.document;
+    const element = document.querySelector('ngc-omnibox-suggestions');
+
+    ngcModifySuggestionsTemplate = ngcModifySuggestionsTemplateFactory([document], templateCache);
+    expect(() => ngcModifySuggestionsTemplate(element))
+        .toThrowError('Cannot include more than one instance of \'ngc-omnibox-suggestion-item\'');
+  });
 });

--- a/spec/tests/angularComponent/ngcModifySuggestionsTemplateFactorySpec.js
+++ b/spec/tests/angularComponent/ngcModifySuggestionsTemplateFactorySpec.js
@@ -54,13 +54,54 @@ const categorizedTemplateOutput = [
   '</div>'
 ].join('');
 
+const loadingElTemplate = [
+  '<ngc-omnibox-suggestion-item>',
+    '{{suggestion.sample_item_text}}',
+  '</ngc-omnibox-suggestion-item>',
+  '<ngc-omnibox-suggestion-loading></ngc-omnibox-suggestion-loading>'
+].join('');
+
+const loadingElTemplateOutput = [
+  '<ngc-omnibox-suggestion-item ng-repeat="suggestion in omnibox.suggestions" ',
+      'suggestion="suggestion" ',
+      'ng-attr-aria-selected="{{suggestionItem.isHighlighted() || undefined}}" ',
+      'ng-attr-aria-readonly="{{suggestionItem.isSelectable() === false || undefined}}" ',
+      'ng-mouseenter="suggestionItem.handleMouseEnter()" ',
+      'ng-mouseleave="suggestionItem.handleMouseLeave()" ng-click="suggestionItem.handleClick()">',
+    '{{suggestion.sample_item_text}}',
+  '</ngc-omnibox-suggestion-item>',
+  '<ngc-omnibox-suggestion-loading role="progressbar" ng-if="omnibox.shouldShowLoadingElement">',
+  '</ngc-omnibox-suggestion-loading>'
+].join('');
+
+const noResultsElTemplate = [
+  '<ngc-omnibox-suggestion-item>',
+    '{{suggestion.sample_item_text}}',
+  '</ngc-omnibox-suggestion-item>',
+  '<ngc-omnibox-suggestion-empty></ngc-omnibox-suggestion-empty>'
+].join('');
+
+const noResultsElTemplateOutput = [
+  '<ngc-omnibox-suggestion-item ng-repeat="suggestion in omnibox.suggestions" ',
+      'suggestion="suggestion" ',
+      'ng-attr-aria-selected="{{suggestionItem.isHighlighted() || undefined}}" ',
+      'ng-attr-aria-readonly="{{suggestionItem.isSelectable() === false || undefined}}" ',
+      'ng-mouseenter="suggestionItem.handleMouseEnter()" ',
+      'ng-mouseleave="suggestionItem.handleMouseLeave()" ng-click="suggestionItem.handleClick()">',
+    '{{suggestion.sample_item_text}}',
+  '</ngc-omnibox-suggestion-item>',
+  //                                                            vv I think this is a bug in jsdom
+  '<ngc-omnibox-suggestion-empty ng-if="!omnibox.hasSuggestions &amp;&amp; !omnibox.isLoading">',
+  '</ngc-omnibox-suggestion-empty>'
+].join('');
+
 /* eslint-enable indent */
 
 describe('ngcOmnibox.angularComponent.ngcModifySuggestionsTemplateFactory', () => {
   const templateCache = {put: () => {}};
   let ngcModifySuggestionsTemplate;
 
-  it('should modify an un-categorized element', () => {
+  it('should modify an un-categorized subcomponent', () => {
     const elementTemplate =
         `<ngc-omnibox-suggestions>${unCategorizedTemplate}</ngc-omnibox-suggestions>`;
     const document = jsdom.jsdom(elementTemplate).defaultView.document;
@@ -70,7 +111,7 @@ describe('ngcOmnibox.angularComponent.ngcModifySuggestionsTemplateFactory', () =
     expect(ngcModifySuggestionsTemplate(element)).toBe(unCategorizedTemplateOutput);
   });
 
-  it('should modify a categorized element', () => {
+  it('should modify a categorized subcomponent', () => {
     const elementTemplate =
         `<ngc-omnibox-suggestions>${categorizedTemplate}</ngc-omnibox-suggestions>`;
     const document = jsdom.jsdom(elementTemplate).defaultView.document;
@@ -78,6 +119,26 @@ describe('ngcOmnibox.angularComponent.ngcModifySuggestionsTemplateFactory', () =
 
     ngcModifySuggestionsTemplate = ngcModifySuggestionsTemplateFactory([document], templateCache);
     expect(ngcModifySuggestionsTemplate(element, 'category-tmpl')).toBe(categorizedTemplateOutput);
+  });
+
+  it('should modify a loading subcomponent', () => {
+    const elementTemplate =
+        `<ngc-omnibox-suggestions>${loadingElTemplate}</ngc-omnibox-suggestions>`;
+    const document = jsdom.jsdom(elementTemplate).defaultView.document;
+    const element = document.querySelector('ngc-omnibox-suggestions');
+
+    ngcModifySuggestionsTemplate = ngcModifySuggestionsTemplateFactory([document], templateCache);
+    expect(ngcModifySuggestionsTemplate(element)).toBe(loadingElTemplateOutput);
+  });
+
+  it('should modify a no-results subcomponent', () => {
+    const elementTemplate =
+        `<ngc-omnibox-suggestions>${noResultsElTemplate}</ngc-omnibox-suggestions>`;
+    const document = jsdom.jsdom(elementTemplate).defaultView.document;
+    const element = document.querySelector('ngc-omnibox-suggestions');
+
+    ngcModifySuggestionsTemplate = ngcModifySuggestionsTemplateFactory([document], templateCache);
+    expect(ngcModifySuggestionsTemplate(element)).toBe(noResultsElTemplateOutput);
   });
 
   it('should only allow one instance of a subcomponent', () => {

--- a/src/angularComponent/ngcModifySuggestionsTemplateFactory.js
+++ b/src/angularComponent/ngcModifySuggestionsTemplateFactory.js
@@ -14,18 +14,10 @@ export default function ngcModifySuggestionsTemplateFactory($document, $template
       templateCacheName = `category-tmpl-${new Date().getTime() * Math.random()}`) {
     const doc = $document[0];
 
-    const categoryEl = element.querySelector(
-      'ngc-omnibox-suggestion-category, [ngc-omnibox-suggestion-category]'
-    );
-    const itemEl = element.querySelector(
-      'ngc-omnibox-suggestion-item, [ngc-omnibox-suggestion-item]'
-    );
-    const loadingEl = element.querySelector(
-      'ngc-omnibox-suggestion-loading, [ngc-omnibox-suggestion-loading]'
-    );
-    const noResultsEl = element.querySelector(
-      'ngc-omnibox-suggestion-empty, [ngc-omnibox-suggestion-empty]'
-    );
+    const categoryEl = getSubcomponent(element, 'ngc-omnibox-suggestion-category');
+    const itemEl = getSubcomponent(element, 'ngc-omnibox-suggestion-item');
+    const loadingEl = getSubcomponent(element, 'ngc-omnibox-suggestion-loading');
+    const noResultsEl = getSubcomponent(element, 'ngc-omnibox-suggestion-empty');
 
     element.setAttribute('role', 'listbox');
 
@@ -54,9 +46,7 @@ export default function ngcModifySuggestionsTemplateFactory($document, $template
 
       itemEl.parentNode.appendChild(itemChildrenEl);
 
-      const itemHeader = element.querySelector(
-        'ngc-omnibox-suggestion-header, [ngc-omnibox-suggestion-header]'
-      );
+      const itemHeader = getSubcomponent(element, 'ngc-omnibox-suggestion-header');
       if (itemHeader) {
         itemHeader.setAttribute('suggestion', 'suggestion');
         itemHeader.setAttribute('ng-attr-aria-selected',
@@ -97,4 +87,25 @@ export default function ngcModifySuggestionsTemplateFactory($document, $template
       return element.innerHTML;
     }
   };
+}
+
+/**
+ * Queries a container for an element reference of a subcomponent, either via a custom element or
+ * via an attribute.
+ *
+ * @private
+ * @param {HTMLElement} container
+ * @param {String} directive
+ * @returns {HTMLElement}
+ */
+function getSubcomponent(container, directive) {
+  const element = container.querySelectorAll(`${directive}, [${directive}]`);
+
+  if (element.length > 1) {
+    throw new Error('Cannot include more than one instance of \'' + directive + '\'');
+  } else if (!element.length) {
+    return null;
+  }
+
+  return element[0];
 }


### PR DESCRIPTION
Also, ditch the part of the README that says the suggestions component will clear its markup, because it just wasn't true. Also, it's useful!

Also added some missing tests.