### PR TITLE
Add filter for suggestion match highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,46 @@ one. If the last one is highlighted then the field is focused.
 - `omnibox.highlightLastChoice()`: Highlights the last choice in the list of choices.
 - `omnibox.highlightNoChoice()`: Un-highlights all choices.
 - `omnibox.isChoiceHighlighted()`: Whether the submitted choice is currently highlighted.
+
+## Highlight Match Filter
+The `ngcOmniboxHighlightMatch` Angular filter can be used to highlight some text in your suggestion
+that matches the query being searched against. It uses a regular expressio to search for the exact
+query being passed, and wraps that match in HTML. By default the filter will wrap it in a `<strong>`
+tag, but you can customize this to be any HTML you like.
+
+_Note that since we're parsing a String as HTML, the filter will throw a warning if you're not using
+`ngSanitize` to make your string safe to convert to HTML._
+
+### Usage
+
+#### Basic Example
+
+```html
+<ngc-omnibox ng-model="myCtrl.model" source="myCtrl.getSuggestions(query)">
+  <ngc-omnibox-field></ngc-omnibox-field>
+
+  <ngc-omnibox-suggestions>
+    <ngc-omnibox-suggestion-item ng-bind-html="suggestion.title | ngcOmniboxHighlightMatch:omnibox.query">
+    </ngc-omnibox-suggestion-item>
+  </ngc-omnibox-suggestions>
+</ngc-omnibox>
+```
+
+#### Custom Markup
+
+If you wish to customize the markup used to wrap your text, you can do so in the second parameter
+passed to the filter. The parameter is a string replacement pattern, which should follow the
+replacement rules for JavaScript's `String.prototype.replace()` function. More information can
+be [found on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter)
+
+```html
+<ngc-omnibox ng-model="myCtrl.model" source="myCtrl.getSuggestions(query)">
+  <ngc-omnibox-field></ngc-omnibox-field>
+
+  <ngc-omnibox-suggestions>
+    <ngc-omnibox-suggestion-item ng-bind-html="suggestion.title | ngcOmniboxHighlightMatch:omnibox.query:'<em class=\'my-highlighted-text\'>$&</em>'">
+    </ngc-omnibox-suggestion-item>
+  </ngc-omnibox-suggestions>
+</ngc-omnibox>
+```
+

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ one. If the last one is highlighted then the field is focused.
 
 ## Highlight Match Filter
 The `ngcOmniboxHighlightMatch` Angular filter can be used to highlight some text in your suggestion
-that matches the query being searched against. It uses a regular expressio to search for the exact
+that matches the query being searched against. It uses a regular expression to search for the exact
 query being passed, and wraps that match in HTML. By default the filter will wrap it in a `<strong>`
 tag, but you can customize this to be any HTML you like.
 

--- a/examples/category-results-materialize.html
+++ b/examples/category-results-materialize.html
@@ -24,6 +24,10 @@
         margin: 0;
       }
 
+      .collection-item strong {
+        color: #fdd835;
+      }
+
       /* Small work around Materialize so input field takes up the remainder of the space from chips */
       .chips {
         display: flex;
@@ -87,7 +91,10 @@
               <div ngc-omnibox-suggestion-item class="collection-item"
                   ng-class="{'active': omnibox.isHighlighted(suggestion)}">
                 <h6>
-                  <strong>{{suggestion.person.firstname}} {{suggestion.person.lastname}}</strong>
+                  <span ng-bind-html="suggestion.person.firstname | ngcOmniboxHighlightMatch:omnibox.query">
+                  </span>
+                  <span ng-bind-html="suggestion.person.lastname | ngcOmniboxHighlightMatch:omnibox.query:'<strong class=\'orange-text lighten-4\'>$&</strong>'">
+                  </span>
                 </h6>
                 <em>{{suggestion.description}} &mdash; {{suggestion.party}}</em>
               </div>

--- a/examples/category-results-materialize.html
+++ b/examples/category-results-materialize.html
@@ -18,6 +18,7 @@
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
         max-height: 500px;
+        background: white;
       }
 
       dl, dt, dd {
@@ -96,7 +97,10 @@
                   <span ng-bind-html="suggestion.person.lastname | ngcOmniboxHighlightMatch:omnibox.query:'<strong class=\'orange-text lighten-4\'>$&</strong>'">
                   </span>
                 </h6>
-                <em>{{suggestion.description}} &mdash; {{suggestion.party}}</em>
+                <em>
+                  {{suggestion.description}} &mdash;
+                  <span ng-bind-html="suggestion.party | ngcOmniboxHighlightMatch:omnibox.query:'<strong class=\'deep-purple-text lighten-4\'>$&</strong>'"></span>
+                </em>
               </div>
             </dd>
           </dl>

--- a/examples/category-results.js
+++ b/examples/category-results.js
@@ -20,7 +20,7 @@
             .then(function (responses) {
               states = responses[0].data;
               fuse = new Fuse(responses[1].data.objects, {
-                keys: ['party', 'person.name'],
+                keys: ['party', 'person.firstname', 'person.lastname'],
                 threshold: 0.3
               });
 

--- a/spec/tests/angularComponent/ngcOmniboxHighlightMatchFilterSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxHighlightMatchFilterSpec.js
@@ -1,0 +1,18 @@
+import ngcOmniboxHighlightMatchFilter from '~/angularComponent/ngcOmniboxHighlightMatchFilter.js';
+
+describe('ngcOmnibox.angularComponent.ngcOmniboxHighlightMatchFilter', () => {
+  const $injector = {has: () => true};
+  const $log = {warn: () => {}};
+  const $sce = {trustAsHtml: (str) => str};
+  const ngcOmniboxHighlightMatch = ngcOmniboxHighlightMatchFilter($injector, $log, $sce);
+
+  it('should surround a match with strong tags by default', () => {
+    expect(ngcOmniboxHighlightMatch('This is my text', 'is my'))
+        .toBe('This <strong>is my</strong> text');
+  });
+
+  it('should surround a match with arbitrary markup', () => {
+    expect(ngcOmniboxHighlightMatch('This is my text', 'is my', '<em class="strong">$&</em>'))
+        .toBe('This <em class="strong">is my</em> text');
+  });
+});

--- a/src/angularComponent/ngcOmniboxHighlightMatchFilter.js
+++ b/src/angularComponent/ngcOmniboxHighlightMatchFilter.js
@@ -1,0 +1,64 @@
+/**
+ * Filter for surrounding text in a suggestion with HTML for highlighting. This is mostly based
+ * on a similar filter in the uib-typeahead project https://github.com/angular-ui/bootstrap
+ *
+ * Usage:
+ *   <ngc-omnibox-suggestion-item
+ *       ng-bind-html="suggestion.title | ngcOmniboxHighlightMatch:omnibox.query">
+ *   </ngc-omnibox-suggestion-item>
+ */
+ngcOmniboxHighlightMatchFilter.$inject = ['$injector', '$log', '$sce'];
+export default function ngcOmniboxHighlightMatchFilter($injector, $log, $sce) {
+
+  /**
+   * Angular Filter for surrounding text with HTML. This is useful for highlighting text in a
+   * suggestion to note what is being matched against.
+   *
+   * @param {String} matchItem -- Entire item of text that can contain a match inside it
+   * @param {String} query -- The query we're trying to highlight in the matchItem
+   * @param {String} replacement -- String replacement pattern to surround the highlighted query
+   *     with HTML. It defaults to '<strong>$&</strong>'.
+   *
+   * @returns {Function}
+   */
+  return function ngcOmniboxHighlightMatch(matchItem, query, replacement = '<strong>$&</strong>') {
+    const isSanitizePresent = $injector.has('$sanitize');
+
+    if (!isSanitizePresent && containsHtml(matchItem)) {
+      $log.warn('Unsafe use, please use ngSanitize');
+    }
+
+    // Replaces the capture string with a the same string inside of a "strong" tag
+    if (query) {
+      matchItem = matchItem.replace(new RegExp(escapeRegexp(query), 'gi'), replacement);
+    }
+
+    // If $sanitize is not present, pack the string in a $sce object for the ng-bind-html directive
+    if (!isSanitizePresent) {
+      matchItem = $sce.trustAsHtml(matchItem);
+    }
+
+    return matchItem;
+  };
+}
+
+/**
+ * Regex: capture the whole query string and replace it with the string that will be used to match
+ * the results, for example if the capture is "a" the result will be \a
+ *
+ * @param {String} queryToEscape
+ * @returns {String}
+ */
+function escapeRegexp(queryToEscape) {
+  return queryToEscape.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
+}
+
+/**
+ * Whether the string contains HTML tags.
+ *
+ * @param {String} str
+ * @returns {Boolean}
+ */
+function containsHtml(str) {
+  return /<.*>/g.test(str);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,18 @@
 import angular from 'angular';
 
 import ngcOmniboxComponent from './angularComponent/ngcOmniboxComponent.js';
-import ngcOmniboxFieldDirective from './angularComponent/ngcOmniboxFieldDirective.js';
+import ngcOmniboxHighlightMatchFilter from './angularComponent/ngcOmniboxHighlightMatchFilter.js';
 import ngcModifySuggestionsTemplateFactory from './angularComponent/ngcModifySuggestionsTemplateFactory.js';
+import ngcOmniboxFieldDirective from './angularComponent/ngcOmniboxFieldDirective.js';
 import ngcOmniboxSuggestionsDirective from './angularComponent/ngcOmniboxSuggestionsDirective.js';
 import ngcOmniboxSuggestionItemDirective from './angularComponent/ngcOmniboxSuggestionItemDirective.js';
 import ngcOmniboxChoicesDirective from './angularComponent/ngcOmniboxChoicesDirective.js';
 
 export default angular.module('ngc.omnibox', [])
   .component('ngcOmnibox', ngcOmniboxComponent)
-  .directive('ngcOmniboxField', ngcOmniboxFieldDirective)
   .factory('ngcModifySuggestionsTemplate', ngcModifySuggestionsTemplateFactory)
+  .filter('ngcOmniboxHighlightMatch', ngcOmniboxHighlightMatchFilter)
+  .directive('ngcOmniboxField', ngcOmniboxFieldDirective)
   .directive('ngcOmniboxSuggestions', ngcOmniboxSuggestionsDirective)
   .directive('ngcOmniboxSuggestionHeader', ngcOmniboxSuggestionItemDirective)
   .directive('ngcOmniboxSuggestionItem', ngcOmniboxSuggestionItemDirective)


### PR DESCRIPTION
The `ngcOmniboxHighlightMatch` filter can be used in conjunction with `ng-bind-html` to wrap a particular string that matches a query in HTML that highlights that text in a suggestion.

Fixes #42