### PR TITLE
Clear the field when ngModel is set to empty string, null, or undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -94,7 +94,13 @@ export default class NgcOmniboxController {
   }
 
   set ngModel(newModel) {
-    this._ngModel = newModel;
+    if (newModel === '' || newModel === null || typeof newModel === 'undefined') {
+      this._ngModel = null;
+      this.query = '';
+      this.onInputChange();
+    } else {
+      this._ngModel = newModel;
+    }
 
     if (Array.isArray(this._ngModel)) {
       const currentPrototype = Object.getPrototypeOf(this._ngModel);


### PR DESCRIPTION
So app-makers can implement their own clear buttons.