### PR TITLE
Clear the current suggestions while loading new ones

### DIFF
--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -449,6 +449,11 @@ export default class NgcOmniboxController {
     this._suggestionsUiList.length = 0;
     this.hint = null;
 
+    // Clear out our current suggestions while we load in the new ones
+    if (Array.isArray(this.suggestions)) {
+      this.suggestions.length = 0;
+    }
+
     this.highlightedIndex = -1; // Forcibly select nothing
     this._showLoading();
     this.hideSuggestions = false;

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -157,6 +157,20 @@ export default class NgcOmniboxController {
     return this._highlightedIndex;
   }
 
+  set hideSuggestions(hide) {
+    this._hideSuggestions = hide;
+
+    // Clear out the suggestions when we hide the panel. This stops from showing old results for
+    // a hot second when we re-open the panel
+    if (hide === true && Array.isArray(this.suggestions)) {
+      this.suggestions.length = 0;
+    }
+  }
+
+  get hideSuggestions() {
+    return this._hideSuggestions;
+  }
+
   /**
   * Highlights a particular suggestion item.
   *
@@ -448,11 +462,6 @@ export default class NgcOmniboxController {
   updateSuggestions() {
     this._suggestionsUiList.length = 0;
     this.hint = null;
-
-    // Clear out our current suggestions while we load in the new ones
-    if (Array.isArray(this.suggestions)) {
-      this.suggestions.length = 0;
-    }
 
     this.highlightedIndex = -1; // Forcibly select nothing
     this._showLoading();


### PR DESCRIPTION
This fixes a confusing UI issue where if the suggestions load in slowly,
you'll see the old suggestions for a while before the new ones pop in.