### PR TITLE
Fix bug where query wasn't getting cleared

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -47,6 +47,18 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     expect(newFieldEl.addEventListener).toHaveBeenCalled();
   });
 
+  it('should clear out the query when the ngModel changes when a match is required', () => {
+    omniboxController.ngModel = ['one'];
+    omniboxController.query = 'my query';
+    omniboxController.ngModel.push('two');
+
+    expect(omniboxController.query).toBe('my query');
+
+    omniboxController.requireMatch = true;
+    omniboxController.ngModel.push('three');
+    expect(omniboxController.query).toBe('');
+  });
+
   describe('when populating suggestions via the source function', () => {
     it('it should empty out the suggestions when resolving to a falsy value', (done, fail) => {
       omniboxController.query = 'my query';

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -670,6 +670,10 @@ export default class NgcOmniboxController {
    */
   _onNgModelChange() {
     this.hasChoices = !!this.multiple && Array.isArray(this._ngModel) && !!this._ngModel.length;
+
+    if (this.requireMatch) {
+      this.query = '';
+    }
   }
 
   _scrollSuggestionIntoView() {


### PR DESCRIPTION
When requireMatch is on, the query should get cleared whenever the model changes since an update to the model is the equivalent of an item getting chosen or unchosen. This only happens when requireMatch is on since when its off the implementor might allow free text searching.