### PR TITLE
Add ability to prevent or delay updating the ngModel on choose/unchoose.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,18 @@ field receives focus, you can use the `target` property of the event object to f
 the entire component, not just the field. This blur event also has logic to reduce the noise that
 sometimes happens where it'll lose focus then immediately regain it, so the blur is called only
 after a timeout to make sure it doesn't re-receive focus first.
-- `onChosen({choice})`: An expression that's called when a suggestion is chosen. In its locals it
-has access to `choice`, which is the item that was chosen.
-- `onUnchosen({choice})`: An expression that's called when a suggestion is unchosen (removed as a
-choice). In its locals it has access to `choice`, which is the item that was unchosen.
+- `onChosen({choice, $event})`: An expression that's called when a suggestion is chosen. In its
+locals it has access to `choice`, which is the item that was chosen, and an `$event` object. The
+`$event` object has the following properties: `isDefaultPrevented`, `preventDefault()`, and
+`performDefault()`. If `isDefaultPrevented` is set to true by calling `preventDefault()` from this
+callback function, then the choice is not automatically added to the ngModel. If you then do want
+the choice to be added, you can call `performDefault()` to do so.
+- `onUnchosen({choice, $event})`: An expression that's called when a suggestion is unchosen (removed as a
+choice). In its locals it has access to `choice`, which is the item that was unchosen, and an
+`$event` object. The `$event` object has the following properties: `isDefaultPrevented`,
+`preventDefault()`, and  `performDefault()`. If `isDefaultPrevented` is set to true by calling
+`preventDefault()` from this callback function, then the choice is not automatically removed from
+the ngModel. If you then do want the choice to be removed, you can call `performDefault()` to do so.
 - `onShowSuggestions({suggestions})`: An expression that's called when the suggestions UI is shown.
 In its locals it has access to `suggestions`.
 - `onHideSuggestions({suggestions})`: An expression that's called when the suggestions UI is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -418,24 +418,25 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
 
   describe('choosing and unchoosing', () => {
     beforeEach(() => {
+      omniboxController.multiple = true;
       omniboxController.ngModel = ['one', 'two'];
     });
 
     it('should set the ngModel to the choice when multiple is off', () => {
+      omniboxController.multiple = false;
+      omniboxController.ngModel = 'one';
       omniboxController.choose('three');
 
       expect(omniboxController.ngModel).toEqual('three');
     });
 
     it('should push the choice to an array when multiple is on', () => {
-      omniboxController.multiple = true;
       omniboxController.choose('three');
 
       expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
     });
 
     it('should not update the ngModel when onChosen event prevents default', () => {
-      omniboxController.multiple = true;
       omniboxController.onChosen = ({$event}) => $event.preventDefault();
       omniboxController.choose('three');
 
@@ -443,7 +444,6 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should update the ngModel when onChosen event prevents then peforms default', (done) => {
-      omniboxController.multiple = true;
       omniboxController.onChosen = ({$event}) => {
         $event.preventDefault();
         expect(omniboxController.ngModel).toEqual(['one', 'two']);
@@ -458,7 +458,6 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should not update the ngModel when choosing if an item is not selectable', () => {
-      omniboxController.multiple = true;
       omniboxController.isSelectable = () => false;
       omniboxController.choose('three');
 
@@ -466,6 +465,7 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should set the ngModel to null when unchoosing if multiple is off', () => {
+      omniboxController.multiple = false;
       omniboxController.ngModel = 'one';
       omniboxController.unchoose('one');
 
@@ -473,14 +473,12 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should remove a choice from the ngModel array when unchoosing if multiple is on', () => {
-      omniboxController.multiple = true;
       omniboxController.unchoose('two');
 
       expect(omniboxController.ngModel).toEqual(['one']);
     });
 
     it('should not update the ngModel when onUnchosen event prevents default', () => {
-      omniboxController.multiple = true;
       omniboxController.onUnchosen = ({$event}) => $event.preventDefault();
       omniboxController.unchoose('two');
 
@@ -488,7 +486,6 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     });
 
     it('should update the ngModel when onUnchosen event prevents then peforms default', (done) => {
-      omniboxController.multiple = true;
       omniboxController.onUnchosen = ({$event}) => {
         $event.preventDefault();
         expect(omniboxController.ngModel).toEqual(['one', 'two']);

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -417,86 +417,87 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
   });
 
   describe('choosing and unchoosing', () => {
-    beforeEach(() => {
-      omniboxController.multiple = true;
-      omniboxController.ngModel = ['one', 'two'];
+    describe('when multiple is off', () => {
+      beforeEach(() => {
+        omniboxController.multiple = false;
+        omniboxController.ngModel = 'one';
+      });
+
+      it('should set the ngModel to the choice when multiple is off', () => {
+        omniboxController.choose('three');
+        expect(omniboxController.ngModel).toEqual('three');
+      });
+
+      it('should set the ngModel to null when unchoosing if multiple is off', () => {
+        omniboxController.unchoose('one');
+        expect(omniboxController.ngModel).toEqual(null);
+      });
     });
 
-    it('should set the ngModel to the choice when multiple is off', () => {
-      omniboxController.multiple = false;
-      omniboxController.ngModel = 'one';
-      omniboxController.choose('three');
+    describe('when multiple is on', () => {
+      beforeEach(() => {
+        omniboxController.multiple = true;
+        omniboxController.ngModel = ['one', 'two'];
+      });
 
-      expect(omniboxController.ngModel).toEqual('three');
-    });
-
-    it('should push the choice to an array when multiple is on', () => {
-      omniboxController.choose('three');
-
-      expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
-    });
-
-    it('should not update the ngModel when onChosen event prevents default', () => {
-      omniboxController.onChosen = ({$event}) => $event.preventDefault();
-      omniboxController.choose('three');
-
-      expect(omniboxController.ngModel).toEqual(['one', 'two']);
-    });
-
-    it('should update the ngModel when onChosen event prevents then peforms default', (done) => {
-      omniboxController.onChosen = ({$event}) => {
-        $event.preventDefault();
-        expect(omniboxController.ngModel).toEqual(['one', 'two']);
-
-        $event.performDefault();
+      it('should push the choice to an array', () => {
+        omniboxController.choose('three');
         expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
+      });
 
-        done();
-      };
+      it('should not update the ngModel when onChosen event prevents default', () => {
+        omniboxController.onChosen = ({$event}) => $event.preventDefault();
+        omniboxController.choose('three');
 
-      omniboxController.choose('three');
-    });
-
-    it('should not update the ngModel when choosing if an item is not selectable', () => {
-      omniboxController.isSelectable = () => false;
-      omniboxController.choose('three');
-
-      expect(omniboxController.ngModel).toEqual(['one', 'two']);
-    });
-
-    it('should set the ngModel to null when unchoosing if multiple is off', () => {
-      omniboxController.multiple = false;
-      omniboxController.ngModel = 'one';
-      omniboxController.unchoose('one');
-
-      expect(omniboxController.ngModel).toEqual(null);
-    });
-
-    it('should remove a choice from the ngModel array when unchoosing if multiple is on', () => {
-      omniboxController.unchoose('two');
-
-      expect(omniboxController.ngModel).toEqual(['one']);
-    });
-
-    it('should not update the ngModel when onUnchosen event prevents default', () => {
-      omniboxController.onUnchosen = ({$event}) => $event.preventDefault();
-      omniboxController.unchoose('two');
-
-      expect(omniboxController.ngModel).toEqual(['one', 'two']);
-    });
-
-    it('should update the ngModel when onUnchosen event prevents then peforms default', (done) => {
-      omniboxController.onUnchosen = ({$event}) => {
-        $event.preventDefault();
         expect(omniboxController.ngModel).toEqual(['one', 'two']);
+      });
 
-        $event.performDefault();
+      it('should update the ngModel when onChosen event prevents then peforms default', (done) => {
+        omniboxController.onChosen = ({$event}) => {
+          $event.preventDefault();
+          expect(omniboxController.ngModel).toEqual(['one', 'two']);
+
+          $event.performDefault();
+          expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
+
+          done();
+        };
+
+        omniboxController.choose('three');
+      });
+
+      it('should not update the ngModel when choosing if an item is not selectable', () => {
+        omniboxController.isSelectable = () => false;
+        omniboxController.choose('three');
+
+        expect(omniboxController.ngModel).toEqual(['one', 'two']);
+      });
+
+      it('should remove a choice from the ngModel array when unchoosing', () => {
+        omniboxController.unchoose('two');
         expect(omniboxController.ngModel).toEqual(['one']);
+      });
 
-        done();
-      };
+      it('should not update the ngModel when onUnchosen event prevents default', () => {
+        omniboxController.onUnchosen = ({$event}) => $event.preventDefault();
+        omniboxController.unchoose('two');
 
-      omniboxController.unchoose('two');
+        expect(omniboxController.ngModel).toEqual(['one', 'two']);
+      });
+
+      it('should update the ngModel when onUnchosen event prevents then peforms default', (done) => {
+        omniboxController.onUnchosen = ({$event}) => {
+          $event.preventDefault();
+          expect(omniboxController.ngModel).toEqual(['one', 'two']);
+
+          $event.performDefault();
+          expect(omniboxController.ngModel).toEqual(['one']);
+
+          done();
+        };
+
+        omniboxController.unchoose('two');
+      });
     });
   });
 

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -434,23 +434,30 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
       expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
     });
 
-    it('should update the ngModel when onChosen returns true', () => {
+    it('should not update the ngModel when onChosen event prevents default', () => {
       omniboxController.multiple = true;
-      omniboxController.onChosen = () => true;
-      omniboxController.choose('three');
-
-      expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
-    });
-
-    it('should not update the ngModel when onChosen returns false', () => {
-      omniboxController.multiple = true;
-      omniboxController.onChosen = () => false;
+      omniboxController.onChosen = ({$event}) => $event.preventDefault();
       omniboxController.choose('three');
 
       expect(omniboxController.ngModel).toEqual(['one', 'two']);
     });
 
-    it('should not update the ngModel if an item is not selectable', () => {
+    it('should update the ngModel when onChosen event prevents then peforms default', (done) => {
+      omniboxController.multiple = true;
+      omniboxController.onChosen = ({$event}) => {
+        $event.preventDefault();
+        expect(omniboxController.ngModel).toEqual(['one', 'two']);
+
+        $event.performDefault();
+        expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
+
+        done();
+      };
+
+      omniboxController.choose('three');
+    });
+
+    it('should not update the ngModel when choosing if an item is not selectable', () => {
       omniboxController.multiple = true;
       omniboxController.isSelectable = () => false;
       omniboxController.choose('three');
@@ -472,20 +479,27 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
       expect(omniboxController.ngModel).toEqual(['one']);
     });
 
-    it('should update the ngModel when onUnchosen returns true', () => {
+    it('should not update the ngModel when onUnchosen event prevents default', () => {
       omniboxController.multiple = true;
-      omniboxController.onUnchosen = () => true;
-      omniboxController.unchoose('two');
-
-      expect(omniboxController.ngModel).toEqual(['one']);
-    });
-
-    it('should not update the ngModel when onUnchosen returns false', () => {
-      omniboxController.multiple = true;
-      omniboxController.onUnchosen = () => false;
+      omniboxController.onUnchosen = ({$event}) => $event.preventDefault();
       omniboxController.unchoose('two');
 
       expect(omniboxController.ngModel).toEqual(['one', 'two']);
+    });
+
+    it('should update the ngModel when onUnchosen event prevents then peforms default', (done) => {
+      omniboxController.multiple = true;
+      omniboxController.onUnchosen = ({$event}) => {
+        $event.preventDefault();
+        expect(omniboxController.ngModel).toEqual(['one', 'two']);
+
+        $event.performDefault();
+        expect(omniboxController.ngModel).toEqual(['one']);
+
+        done();
+      };
+
+      omniboxController.unchoose('two');
     });
   });
 

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -22,6 +22,8 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     omniboxController = new NgcOmniboxController([document], [fakeEl], {$apply() {}});
     omniboxController._suggestionElements = [fakeEl, fakeEl, fakeEl, fakeEl];
     omniboxController.isSelectable = () => {};
+    omniboxController.onChosen = () => {};
+    omniboxController.onUnchosen = () => {};
   });
 
   it('should inject $document, $element, and $scope', () => {
@@ -411,6 +413,79 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
       omniboxController.ngModel.splice(1, 1);
       expect(omniboxController.ngModel.toString()).toBe('one,three');
       expect(omniboxController._onNgModelChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('choosing and unchoosing', () => {
+    beforeEach(() => {
+      omniboxController.ngModel = ['one', 'two'];
+    });
+
+    it('should set the ngModel to the choice when multiple is off', () => {
+      omniboxController.choose('three');
+
+      expect(omniboxController.ngModel).toEqual('three');
+    });
+
+    it('should push the choice to an array when multiple is on', () => {
+      omniboxController.multiple = true;
+      omniboxController.choose('three');
+
+      expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
+    });
+
+    it('should update the ngModel when onChosen returns true', () => {
+      omniboxController.multiple = true;
+      omniboxController.onChosen = () => true;
+      omniboxController.choose('three');
+
+      expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
+    });
+
+    it('should not update the ngModel when onChosen returns false', () => {
+      omniboxController.multiple = true;
+      omniboxController.onChosen = () => false;
+      omniboxController.choose('three');
+
+      expect(omniboxController.ngModel).toEqual(['one', 'two']);
+    });
+
+    it('should not update the ngModel if an item is not selectable', () => {
+      omniboxController.multiple = true;
+      omniboxController.isSelectable = () => false;
+      omniboxController.choose('three');
+
+      expect(omniboxController.ngModel).toEqual(['one', 'two']);
+    });
+
+    it('should set the ngModel to null when unchoosing if multiple is off', () => {
+      omniboxController.ngModel = 'one';
+      omniboxController.unchoose('one');
+
+      expect(omniboxController.ngModel).toEqual(null);
+    });
+
+    it('should remove a choice from the ngModel array when unchoosing if multiple is on', () => {
+      omniboxController.multiple = true;
+      omniboxController.unchoose('two');
+
+      expect(omniboxController.ngModel).toEqual(['one']);
+    });
+
+    it('should update the ngModel when onUnchosen returns true', () => {
+      omniboxController.multiple = true;
+      omniboxController.onUnchosen = () => true;
+      omniboxController.unchoose('two');
+
+      expect(omniboxController.ngModel).toEqual(['one']);
+    });
+
+    it('should not update the ngModel when onUnchosen returns false', () => {
+      omniboxController.multiple = true;
+      omniboxController.onUnchosen = () => false;
+      omniboxController.unchoose('two');
+
+      expect(omniboxController.ngModel).toEqual(['one', 'two']);
     });
   });
 

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -393,7 +393,9 @@ export default class NgcOmniboxController {
    * @param {Boolean} shouldFocusField -- Whether to focus the input field after choosing
    */
   choose(item, shouldFocusField = true) {
-    if (item && !(Array.isArray(this.ngModel) && this.ngModel.indexOf(item) >= 0) &&
+    const shouldChoose = this.onChosen({choice: item}) !== false;
+
+    if (shouldChoose && item && !(Array.isArray(this.ngModel) && this.ngModel.indexOf(item) >= 0) &&
         this.isSelectable({suggestion: item}) !== false) {
       if (this.multiple) {
         this.ngModel = this.ngModel || [];
@@ -401,8 +403,6 @@ export default class NgcOmniboxController {
       } else {
         this.ngModel = item;
       }
-
-      this.onChosen({choice: item});
 
       this.query = '';
       shouldFocusField && this.focus();
@@ -418,14 +418,14 @@ export default class NgcOmniboxController {
    * @param {Boolean} shouldFocusField -- Whether to focus the input field after unchoosing
    */
   unchoose(item, shouldFocusField = true) {
-    if (item) {
+    const shouldUnchoose = this.onUnchosen({choice: item}) !== false;
+
+    if (shouldUnchoose && item) {
       if (Array.isArray(this.ngModel)) {
         this.ngModel.splice(this.ngModel.indexOf(item), 1);
       } else if (!this.multiple) {
         this.ngModel = null;
       }
-
-      this.onUnchosen({choice: item});
 
       shouldFocusField && this.focus();
     }


### PR DESCRIPTION
`onChosen` and `onUnchosen` now get access to an `$event` object in their locals which let them
call `preventDefault()` to prevent updating of the model, and later `performDefault()` to perform it.

Also, added unit tests for the `choose` and `unchoose` functions, including these new features.