### PR TITLE
Fix bugs with choose/unchoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -466,6 +466,21 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
         omniboxController.choose('three');
       });
 
+      it('should not add dupes to ngModel when onChosen event prevents/peforms default', (done) => {
+        omniboxController.onChosen = ({$event}) => {
+          $event.preventDefault();
+
+          omniboxController.ngModel.push('three');
+
+          $event.performDefault();
+          expect(omniboxController.ngModel).toEqual(['one', 'two', 'three']);
+
+          done();
+        };
+
+        omniboxController.choose('three');
+      });
+
       it('should not update the ngModel when choosing if an item is not selectable', () => {
         omniboxController.isSelectable = () => false;
         omniboxController.choose('three');

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -393,8 +393,7 @@ export default class NgcOmniboxController {
    * @param {Boolean} shouldFocusField -- Whether to focus the input field after choosing
    */
   choose(item, shouldFocusField = true) {
-    if (item && !(Array.isArray(this.ngModel) && this.ngModel.indexOf(item) >= 0) &&
-        this.isSelectable({suggestion: item}) !== false) {
+    if (item && this.isSelectable({suggestion: item}) !== false) {
 
       const $event = {
         isDefaultPrevented: false,
@@ -402,21 +401,21 @@ export default class NgcOmniboxController {
         performDefault: () => {
           $event.isDefaultPrevented = false;
 
-          if (this.multiple) {
+          if (this.multiple && !(Array.isArray(this.ngModel) && this.ngModel.indexOf(item) >= 0)) {
             this.ngModel = this.ngModel || [];
             this.ngModel.push(item);
-          } else {
+          } else if (!this.multiple) {
             this.ngModel = item;
           }
-
-          this.query = '';
-          shouldFocusField && this.focus();
-          this.hideSuggestions = true;
         }
       };
 
       this.onChosen({choice: item, $event});
       !$event.isDefaultPrevented && $event.performDefault();
+
+      this.query = '';
+      shouldFocusField && this.focus();
+      this.hideSuggestions = true;
     }
   }
 
@@ -433,7 +432,7 @@ export default class NgcOmniboxController {
         isDefaultPrevented: false,
         preventDefault: () => $event.isDefaultPrevented = true,
         performDefault: () => {
-          if (Array.isArray(this.ngModel)) {
+          if (this.multiple && Array.isArray(this.ngModel)) {
             this.ngModel.splice(this.ngModel.indexOf(item), 1);
           } else if (!this.multiple) {
             this.ngModel = null;


### PR DESCRIPTION
1. If the default was prevented, then performed, we were no longer
  checking to make sure it wasn't already added to the list of choices.
  This meant that if the implementor added it themselves it would be
  then added twice
2. The UI behavior performed once a choice was added was being
  grouped into the performDefault function, meaning if the implementor
  wanted to update the model themselves and prevented default, the UI
  would be out of sync. I've pulled that out of the performDefault
  function and now always do it since it has nothing to do with the data
  model
