### PR TITLE
Fix focus bug when clicking on a token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/src/angularComponent/ngcOmniboxChoicesDirective.js
+++ b/src/angularComponent/ngcOmniboxChoicesDirective.js
@@ -46,7 +46,6 @@ export default function ngcOmniboxChoicesDirective() {
         token.setAttribute('tabindex', -1);
         token.setAttribute('ng-repeat', 'choice in omnibox.ngModel');
         token.setAttribute('ng-focus', 'omnibox.highlightedChoice = choice');
-        token.setAttribute('ng-blur', 'omnibox.highlightedChoice = null');
       } else {
         throw new Error('ngc-omnibox-choices requires a root HTML element');
       }

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -1,4 +1,4 @@
-import {KEY, isSelectKey, isVerticalMovementKey} from '../keyboard.js';
+import {KEY, isModifierKey, isSelectKey, isVerticalMovementKey} from '../keyboard.js';
 
 // Protects against multiple key events firing in a row without disallowing holding down the key
 const KEY_REPEAT_DELAY = 150;
@@ -595,7 +595,9 @@ export default class NgcOmniboxController {
     }
   }
 
-  _handleKeyUp({keyCode, shiftKey}) {
+  _handleKeyUp(event) {
+    const {keyCode} = event;
+
     if (this.hasChoices) {
       if (this.doc.activeElement === this._fieldElement) {
         this.selectionStartKeyUp = this.doc.activeElement.selectionStart;
@@ -636,7 +638,7 @@ export default class NgcOmniboxController {
           const choice = this.highlightedChoice;
           this.highlightNextChoice();
           this.unchoose(choice, false);
-        } else {
+        } else if (!isModifierKey(event)) {
           // We can assume the user's keypress isn't meant to modify the highlighted choice and
           // they instead just want to type as normal on the field, so we'll deselect the choice
           // and focus the field which allows the user to type as normal
@@ -645,7 +647,7 @@ export default class NgcOmniboxController {
           // The field didn't have focus on keydown so it wasn't able to write out the character
           // the user pressed, so we need to do that manually
           const str = String.fromCharCode(keyCode);
-          this._fieldElement.value += !shiftKey ? str.toLowerCase() : str;
+          this._fieldElement.value += !event.shiftKey ? str.toLowerCase() : str;
         }
       }
     }

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -482,6 +482,7 @@ export default class NgcOmniboxController {
     this.hint = null;
 
     this.highlightedIndex = -1; // Forcibly select nothing
+    this.highlightedChoice = null;
     this._showLoading();
     this.hideSuggestions = false;
 
@@ -594,7 +595,7 @@ export default class NgcOmniboxController {
     }
   }
 
-  _handleKeyUp({keyCode}) {
+  _handleKeyUp({keyCode, shiftKey}) {
     if (this.hasChoices) {
       if (this.doc.activeElement === this._fieldElement) {
         this.selectionStartKeyUp = this.doc.activeElement.selectionStart;
@@ -635,6 +636,16 @@ export default class NgcOmniboxController {
           const choice = this.highlightedChoice;
           this.highlightNextChoice();
           this.unchoose(choice, false);
+        } else {
+          // We can assume the user's keypress isn't meant to modify the highlighted choice and
+          // they instead just want to type as normal on the field, so we'll deselect the choice
+          // and focus the field which allows the user to type as normal
+          this.highlightedChoice = null;
+          this._fieldElement.focus();
+          // The field didn't have focus on keydown so it wasn't able to write out the character
+          // the user pressed, so we need to do that manually
+          const str = String.fromCharCode(keyCode);
+          this._fieldElement.value += !shiftKey ? str.toLowerCase() : str;
         }
       }
     }


### PR DESCRIPTION
Previously, the highlighted choice was getting cleared when a token was blurred, which was a silly thing to do since we blur the token and focus the component so we can better handle keyboard events. This would cause clicking on a token to highlight and then instantly unhighlight it.

Additionally, now when you start typing like normal while a token is highlighted, we focus the field, unhighlight the token, and input the text into the field so the user doesn't have to bother unhighlighting when typing.