### PR TITLE
Call updateSuggestions w/o query on input change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -24,6 +24,8 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
     omniboxController.isSelectable = () => {};
     omniboxController.onChosen = () => {};
     omniboxController.onUnchosen = () => {};
+    omniboxController.canShowSuggestions = () => {};
+    omniboxController.source = () => Promise.resolve([]);
   });
 
   it('should inject $document, $element, and $scope', () => {

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -521,7 +521,9 @@ export default class NgcOmniboxController {
     if (!this.query) {
       this.hideSuggestions = true;
       this.hint = null;
-    } else {
+    }
+
+    if (this.canShowSuggestions({query: this.query, omnibox: this}) !== false) {
       this.updateSuggestions();
     }
   }


### PR DESCRIPTION
As long as `canShowSuggestions()` is still cool with it.

This removes the assumption that the implementor doesn't want to do
something with the suggestions even when there's no query. They
might want to show something like instructions or helper UI, or even
some pre-generated default suggestions. This is now all possible.