### PR TITLE
Ignore input change events that happen when the field is blurred

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngc-omnibox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A modern, flexible, Angular 1.x autocomplete library with limited assumptions.",
   "main": "dist/ngc-omnibox.js",
   "scripts": {

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -523,7 +523,8 @@ export default class NgcOmniboxController {
       this.hint = null;
     }
 
-    if (this.canShowSuggestions({query: this.query, omnibox: this}) !== false) {
+    const isFieldFocused = this.doc.activeElement === this._fieldElement;
+    if (isFieldFocused && this.canShowSuggestions({query: this.query, omnibox: this}) !== false) {
       this.updateSuggestions();
     }
   }


### PR DESCRIPTION
This was leading to a situation where the suggestions would show if you changed the query from outside the omnibox, since `onInputChange` fires when the query changes.