### PR TITLE
Add scrollIntoViewAlignToTop binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ behavior of the omnibox:
        highlight the first suggestion, and going to the beginning and hitting up will highlight the
        last.
     4. Hitting ESC will close the list of suggestions and clear the field.
+- `scrollIntoViewAlignToTop {Boolean}`: An expression that should evaluate to a Boolean that
+determines the value of AlignToTop that is given into scrollIntoView() when scrolling Omnibox
+suggestions into view.  Defaults to false.  It's useful to configure this when using the Omnibox
+inside of a scrollable container.
 
 ## Omnibox Event Bindings
 

--- a/src/angularComponent/ngcOmniboxComponent.js
+++ b/src/angularComponent/ngcOmniboxComponent.js
@@ -38,6 +38,10 @@ import NgcOmniboxController from './ngcOmniboxController.js';
  *       scope, access to a string called `query` which is the current query being searched on.
  * - `requireMatch {Boolean}`: An expression that should evaluate to a Boolean that determines if a
  *       matched suggestion is required for the field (defaults to `false`).
+ * - `scrollIntoViewAlignToTop {Boolean}`: An expression that should evaluate to a Boolean that
+ *       determines the value of AlignToTop that is given into scrollIntoView() when scrolling
+ *       Omnibox suggestions into view.  Defaults to false.  It's useful to configure this when
+ *       using the Omnibox inside of a scrollable container.
  *
  * The component has no template, all content that does not map to one of the sub-components will
  * be displayed in the final output as-is and un-modified.
@@ -69,6 +73,7 @@ export default {
     onChosen: '&',
     onUnchosen: '&',
     onShowSuggestions: '&',
-    onHideSuggestions: '&'
+    onHideSuggestions: '&',
+    scrollIntoViewAlignToTop: '<?'
   }
 };

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -729,7 +729,11 @@ export default class NgcOmniboxController {
       if (selectedEl) {
         if (typeof selectedEl.scrollIntoView === 'function') {
           // Standard way
-          selectedEl.scrollIntoView(false);
+          if (this.scrollIntoViewAlignToTop) {
+            selectedEl.scrollIntoView(true);
+          } else {
+            selectedEl.scrollIntoView(false);
+          }
         } else if (typeof selectedEl.scrollIntoViewIfNeeded === 'function') {
           // Non-standard way (webkit-like browsers)
           selectedEl.scrollIntoViewIfNeeded();


### PR DESCRIPTION
To use the Omnibox inside of a scrollable container, we need a way
to control the scrollIntoView behavior for the suggestions.