### PR TITLE
Add circle-CI 2.0 configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+   build:
+     docker:
+       - image: circleci/node:10.15.3
+     steps:
+       - run: echo "circleCI online"
+       - checkout
+       - run: npm install
+       - run: npm test


### PR DESCRIPTION
Previously, ngc-omnibox was on circleCI 1.0, which got sunsetted on
Mar 15, 2019.

This will allow new pull requests to run through circle CI before publishing