### PR TITLE
Update babelrc to only use istanbul when in test env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,13 @@
   "plugins": [
     ["babel-plugin-root-import", {
       "rootPathSuffix": "src"
-    }],
-    "istanbul"
-  ]
+    }]
+  ],
+  "env": {
+    "test": {
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bundle": "webpack --mode=production --progress --colors",
     "dev": "webpack --mode=development --progress --colors --watch",
-    "test": "nyc babel-node node_modules/.bin/jasmine && eslint . && npm run report-coverage",
+    "test": "nyc babel-node --env-name test node_modules/.bin/jasmine && eslint . && npm run report-coverage",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov",
     "prepublish": "npm run bundle",
     "lint:fix": "eslint . --fix"


### PR DESCRIPTION
Previously the plugin was being used for all environments which results
in code coverage being included in the bundle