### PR TITLE
Add support for disabling scrollIntoView

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ behavior of the omnibox:
 determines the value of AlignToTop that is given into scrollIntoView() when scrolling Omnibox
 suggestions into view.  Defaults to false.  It's useful to configure this when using the Omnibox
 inside of a scrollable container.
+- `shouldScrollIntoView {Boolean}`: An expression that should evaluate to a Boolean that
+determines whether to scroll suggestions into view at all. Defaults to true.
 
 ## Omnibox Event Bindings
 

--- a/src/angularComponent/ngcOmniboxComponent.js
+++ b/src/angularComponent/ngcOmniboxComponent.js
@@ -42,6 +42,8 @@ import NgcOmniboxController from './ngcOmniboxController.js';
  *       determines the value of AlignToTop that is given into scrollIntoView() when scrolling
  *       Omnibox suggestions into view.  Defaults to false.  It's useful to configure this when
  *       using the Omnibox inside of a scrollable container.
+ * - `shouldScrollIntoView {Boolean}`: An expression that should evaluate to a Boolean that
+ *       determines whether to scroll suggestions into view at all. Defaults to true.
  *
  * The component has no template, all content that does not map to one of the sub-components will
  * be displayed in the final output as-is and un-modified.
@@ -74,6 +76,7 @@ export default {
     onUnchosen: '&',
     onShowSuggestions: '&',
     onHideSuggestions: '&',
-    scrollIntoViewAlignToTop: '<?'
+    scrollIntoViewAlignToTop: '<?',
+    shouldScrollIntoView: '<?'
   }
 };

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -726,6 +726,9 @@ export default class NgcOmniboxController {
   }
 
   _scrollSuggestionIntoView() {
+    if (this.shouldScrollIntoView === false) {
+      return;
+    }
     // Disable highlighting while scrolling so the mouse doesn't accidentally highlight a new item
     this.isHighlightingDisabled = true;
 


### PR DESCRIPTION
The `shouldScrollIntoView` prop is useful when the omnibox component is inside an unconventional scroll container.