### PR TITLE
Unit tests for disabling scrollIntoView

### DIFF
--- a/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
+++ b/spec/tests/angularComponent/ngcOmniboxControllerSpec.js
@@ -657,5 +657,20 @@ describe('ngcOmnibox.angularComponent.ngcOmniboxController', () => {
       omniboxController.highlightedChoice = null;
       expect(omniboxController.fieldElement.focus).toHaveBeenCalled();
     });
+
+    it('should call scrollSuggestionIntoView by default', () => {
+      const scrollSuggestionIntoViewSpy = spyOn(omniboxController, '_scrollSuggestionIntoView');
+      omniboxController.suggestions = ['test', 'me'];
+      omniboxController.highlightNextSuggestion();
+      expect(scrollSuggestionIntoViewSpy).toHaveBeenCalled();
+    });
+
+    it('should not call scrollSuggestionIntoView when shouldScrollIntoView is false', () => {
+      const scrollSuggestionIntoViewSpy = spyOn(omniboxController, '_scrollSuggestionIntoView');
+      omniboxController.shouldScrollIntoView = false;
+      omniboxController.suggestions = ['test', 'me'];
+      omniboxController.highlightNextSuggestion();
+      expect(scrollSuggestionIntoViewSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/angularComponent/ngcOmniboxController.js
+++ b/src/angularComponent/ngcOmniboxController.js
@@ -240,7 +240,9 @@ export default class NgcOmniboxController {
       return this.highlightPreviousSuggestion(startHighlightIndex);
     }
 
-    this._scrollSuggestionIntoView();
+    if (this.shouldScrollIntoView !== false) {
+      this._scrollSuggestionIntoView();
+    }
 
     return newIndex;
   }
@@ -282,7 +284,9 @@ export default class NgcOmniboxController {
       return this.highlightNextSuggestion(startHighlightIndex);
     }
 
-    this._scrollSuggestionIntoView();
+    if (this.shouldScrollIntoView !== false) {
+      this._scrollSuggestionIntoView();
+    }
 
     return newIndex;
   }
@@ -726,9 +730,6 @@ export default class NgcOmniboxController {
   }
 
   _scrollSuggestionIntoView() {
-    if (this.shouldScrollIntoView === false) {
-      return;
-    }
     // Disable highlighting while scrolling so the mouse doesn't accidentally highlight a new item
     this.isHighlightingDisabled = true;
 


### PR DESCRIPTION
I recently added a PR for adding support for disabling `scrollIntoView` functionality. This PR adds unit tests. I also did a small refactor:
- Previously, at the beginning of the `_scrollSuggestionIntoView` function, I returned early when `shouldScrollIntoView` property was `false`.
- Now, instead, I am not calling `_scrollSuggestionIntoView` when `shouldScrollIntoView` property is false.